### PR TITLE
Fix to allow adding mob drops to preexisting mobs

### DIFF
--- a/src/main/java/jeresources/registry/MobRegistry.java
+++ b/src/main/java/jeresources/registry/MobRegistry.java
@@ -40,7 +40,7 @@ public class MobRegistry
     public void addDrops(Class<? extends EntityLivingBase> entity, DropItem... drops)
     {
         for (MobEntry entry : registry)
-            if (ReflectionHelper.isInstanceOf(entry.getClass(), entity))
+            if (ReflectionHelper.isInstanceOf(entry.getEntity().getClass(), entity))
                 entry.addDrops(drops);
     }
 }


### PR DESCRIPTION
MobEntry could never be an instance of entity passed in, but the one
returned by getEntity() is what needs to be compared here.