### PR TITLE
Cache block drops from blocks without TEs

### DIFF
--- a/src/main/java/jeresources/profiling/ChunkProfiler.java
+++ b/src/main/java/jeresources/profiling/ChunkProfiler.java
@@ -56,26 +56,14 @@ public class ChunkProfiler implements Runnable {
                 for (int z = 0; z < CHUNK_SIZE; z++) {
                     blockPos.setPos(x + chunk.xPosition * CHUNK_SIZE, y, z + chunk.zPosition * CHUNK_SIZE);
                     IBlockState blockState = chunk.getBlockState(x, y, z);
-                    Block block = blockState.getBlock();
-                    int meta = block.getMetaFromState(blockState);
-                    ItemStack pickBlock = null;
-                    try {
-                        pickBlock = block.getPickBlock(blockState, rayTraceResult, world, blockPos, player);
-                    } catch (Exception ignored) {
-                    }
-
-                    final String key;
-                    if (pickBlock == null || pickBlock.getItem() == null) {
-                        key = block.getRegistryName().toString() + ':' + meta;
-                    } else {
-                        key = MapKeys.getKey(pickBlock);
-                    }
+                    final String key = MapKeys.getKey(blockState, rayTraceResult, world, blockPos, player);
 
                     if (!dimensionData.dropsMap.containsKey(key)) {
-                        dimensionData.dropsMap.put(key, getDrops(block, world, blockPos, blockState));
+                        dimensionData.dropsMap.put(key, getDrops(world, blockPos, blockState));
                     }
 
                     if (!dimensionData.silkTouchMap.containsKey(key)) {
+                        Block block = blockState.getBlock();
                         boolean canSilkTouch = block.canSilkHarvest(world, blockPos, blockState, player);
                         dimensionData.silkTouchMap.put(key, canSilkTouch);
                     }
@@ -103,9 +91,10 @@ public class ChunkProfiler implements Runnable {
         this.timer.endChunk(dimId);
     }
 
-    public static Map<String, Map<Integer, Float>> getDrops(Block block, IBlockAccess world, BlockPos pos, IBlockState state) {
+    public static Map<String, Map<Integer, Float>> getDrops(IBlockAccess world, BlockPos pos, IBlockState state) {
         final int totalTries = 10000;
 
+        Block block = state.getBlock();
         final Map<String, Map<Integer, Float>> resultMap = new HashMap<>();
         for (int fortune = 0; fortune <= 3; fortune++) {
             final Map<String, Integer> dropsMap = new HashMap<>();

--- a/src/main/java/jeresources/util/MapKeys.java
+++ b/src/main/java/jeresources/util/MapKeys.java
@@ -1,23 +1,74 @@
 package jeresources.util;
 
+import javax.annotation.Nullable;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import jeresources.api.drop.LootDrop;
 import jeresources.api.restrictions.Restriction;
 import jeresources.entry.WorldGenEntry;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
 
 public class MapKeys {
+
+    private static final Cache<IBlockState, String> keyCache = CacheBuilder.newBuilder()
+            .expireAfterAccess(30, TimeUnit.SECONDS)
+            .build();
+
+    @Nullable
+    public static String getKey(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
+        Block block = state.getBlock();
+        if (!block.hasTileEntity(state)) {
+            try {
+                return keyCache.get(state, () -> getKeyUncached(block, state, target, world, pos, player));
+            } catch (ExecutionException e) {
+                LogHelper.error("Cache error", e);
+            }
+        }
+
+        return getKeyUncached(block, state, target, world, pos, player);
+    }
+
+    @Nullable
+    private static String getKeyUncached(Block block, IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
+        int meta = block.getMetaFromState(state);
+        ItemStack pickBlock = null;
+        try {
+            pickBlock = block.getPickBlock(state, target, world, pos, player);
+        } catch (Exception ignored) {
+        }
+
+        if (pickBlock == null || pickBlock.getItem() == null) {
+            return block.getRegistryName().toString() + ':' + meta;
+        } else {
+            return getKey(pickBlock);
+        }
+    }
+
+    @Nullable
     public static String getKey(ItemStack drop) {
         if (drop == null)
             return null;
         Item item = drop.getItem();
         if (item == null)
             return null;
-        String key = item.getRegistryName().toString() + ':' + drop.getMetadata();
+        String registryName = item.getRegistryName().toString();
+        StringBuilder key = new StringBuilder(registryName);
+        key.append(":").append(drop.getMetadata());
         if (drop.getTagCompound() != null)
-            key += ':' + drop.getTagCompound().toString();
-        return key;
+            key.append(":").append(drop.getTagCompound());
+        return key.toString();
     }
 
     public static String getKey(IPlantable plant) {


### PR DESCRIPTION
Saves on a LOT of memory churn from strings and quite a bit of computation too.
There will probably be some magical snowflake block that gets the wrong drops because of this but everything I tested looks fine.