### PR TITLE
Most likely resolve #223: don't wipe out generic information for entities

### DIFF
--- a/src/main/java/jeresources/util/LootTableHelper.java
+++ b/src/main/java/jeresources/util/LootTableHelper.java
@@ -139,7 +139,7 @@ public class LootTableHelper {
         for (Map.Entry<DyeColor, ResourceLocation> entry : sheepColors.entrySet()) {
             ResourceLocation lootTableList = entry.getValue();
             DyeColor dyeColor = entry.getKey();
-            mobTableBuilder.add(lootTableList, EntityType.SHEEP, entity -> entity.setFleeceColor(dyeColor));
+            mobTableBuilder.addSheep(lootTableList, EntityType.SHEEP, dyeColor);
         }
 
         for (EntityType entityType : ForgeRegistries.ENTITIES) {

--- a/src/main/java/jeresources/util/MobTableBuilder.java
+++ b/src/main/java/jeresources/util/MobTableBuilder.java
@@ -1,12 +1,13 @@
 package jeresources.util;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.passive.SheepEntity;
+import net.minecraft.item.DyeColor;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
-import javax.annotation.Nullable;
-import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -18,25 +19,26 @@ public class MobTableBuilder {
         this.world = world;
     }
 
-    public <T extends LivingEntity> void add(ResourceLocation resourceLocation, EntityType<T> entityType) {
-        add(resourceLocation, entityType, null);
+    public void add(ResourceLocation resourceLocation, EntityType<?> entityType) {
+        Entity entity = entityType.create(world);
+        if (entity instanceof LivingEntity) {
+            mobTables.put(resourceLocation, (LivingEntity) entity);
+        } else {
+            if (entity != null) {
+                entity.remove();
+            }
+        }
     }
 
-    public <T extends LivingEntity> void add(ResourceLocation resourceLocation, EntityType<T> entityType, @Nullable EntityPropertySetter<T> entityPropertySetter) {
-        T LivingEntity = entityType.create(world);
-        if (LivingEntity != null) {
-            if (entityPropertySetter != null) {
-                entityPropertySetter.setProperties(LivingEntity);
-            }
-            mobTables.put(resourceLocation, LivingEntity);
+    public void addSheep(ResourceLocation resourceLocation, EntityType<SheepEntity> entityType, DyeColor dye) {
+        SheepEntity entity = entityType.create(world);
+        if (entity != null) {
+            entity.setFleeceColor(dye);
+            mobTables.put(resourceLocation, entity);
         }
     }
 
     public Map<ResourceLocation, LivingEntity> getMobTables() {
         return mobTables;
-    }
-
-    public interface EntityPropertySetter<T extends LivingEntity> {
-        void setProperties(T entity);
     }
 }


### PR DESCRIPTION
Likewise, don't force de-parameterized unknown EntityType<?>s into
EntityType<LivingEntity> and cause initialisation errors. I don't
believe this will impact start-up time at all as attempts would always
be made to instantiate and create new instances of these entities.

I've taken the liberty of breaking the sheep-related (i.e., entity
properties) function down into an actual SheepEntity-specific function,
as that was its only use: it seems senseless to be using parameterized
overloads with passing null when it's only ever used on Sheep.

The environmental changes I had to make in order to get this to even run
in my workspace were a little gnarly, but I believe it is functionally
correct.