### PR TITLE
Include license option in mods.toml

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -2,6 +2,9 @@
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
 loaderVersion="[32,)" #mandatory
+# The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
+# Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
+license="'Don't Be a Jerk' non-commercial care-free license" #mandatory
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod


### PR DESCRIPTION
Mandatory as of [forge 1.16.2](https://github.com/MinecraftForge/MinecraftForge/blob/fe43088c96cf65c6793260eae96416871a9eb8f2/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java#L67).

This is just a sample license entry I picked for you based off of your license. If you want to change it to something else, go ahead. But just know that it is now a required field as of 1.16.2.  I have a feeling this might be related to #254 but I'm not too sure without more information.