### PR TITLE
Optimize load time

### DIFF
--- a/src/main/java/jeresources/compatibility/CompatBase.java
+++ b/src/main/java/jeresources/compatibility/CompatBase.java
@@ -11,16 +11,37 @@ import jeresources.registry.PlantRegistry;
 import jeresources.registry.WorldGenRegistry;
 import jeresources.util.FakeClientLevel;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 
+import javax.annotation.Nullable;
+
 public abstract class CompatBase {
+    @Nullable
+    private static Level fakeClientLevel = null;
+
     public static Level getLevel() {
-        Level level = Minecraft.getInstance().level;
-        if (level == null) {
-            level = new FakeClientLevel();
+        Minecraft minecraft = Minecraft.getInstance();
+        IntegratedServer integratedServer = minecraft.getSingleplayerServer();
+
+        if (integratedServer != null) {
+            ServerLevel serverLevel = integratedServer.getLevel(Level.OVERWORLD);
+            if (serverLevel != null) {
+                return serverLevel;
+            }
         }
-        return level;
+
+        Level level = minecraft.level;
+        if (level != null) {
+            return level;
+        }
+
+        if (fakeClientLevel == null) {
+            fakeClientLevel = new FakeClientLevel();
+        }
+        return fakeClientLevel;
     }
 
     public abstract void init(boolean worldGen);

--- a/src/main/java/jeresources/compatibility/MobRegistryImpl.java
+++ b/src/main/java/jeresources/compatibility/MobRegistryImpl.java
@@ -33,7 +33,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, int minExp, int maxExp, String[] biomes, ResourceLocation lootTable) {
         try {
-            rawRegisters.put(new MobEntry(entity, lightLevel, minExp, maxExp, biomes), lootTable);
+            rawRegisters.put(MobEntry.create(() -> entity, lightLevel, minExp, maxExp, biomes), lootTable);
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -42,7 +42,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, int minExp, int maxExp, ResourceLocation lootTable) {
         try {
-            rawRegisters.put(new MobEntry(entity, lightLevel, minExp, maxExp), lootTable);
+            rawRegisters.put(MobEntry.create(() -> entity, lightLevel, minExp, maxExp), lootTable);
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -51,7 +51,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, int exp, String[] biomes, ResourceLocation lootTable) {
         try {
-            rawRegisters.put(new MobEntry(entity, lightLevel, exp, biomes), lootTable);
+            rawRegisters.put(MobEntry.create(() -> entity, lightLevel, exp, biomes), lootTable);
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -60,7 +60,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, int exp, ResourceLocation lootTable) {
         try {
-            rawRegisters.put(new MobEntry(entity, lightLevel, exp), lootTable);
+            rawRegisters.put(MobEntry.create(() -> entity, lightLevel, exp), lootTable);
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -69,7 +69,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, String[] biomes, ResourceLocation lootTable) {
         try {
-            rawRegisters.put(new MobEntry(entity, lightLevel, biomes), lootTable);
+            rawRegisters.put(MobEntry.create(() -> entity, lightLevel, biomes), lootTable);
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -78,7 +78,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, ResourceLocation lootTable) {
         try {
-            rawRegisters.put(new MobEntry(entity, lightLevel), lootTable);
+            rawRegisters.put(MobEntry.create(() -> entity, lightLevel), lootTable);
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -87,7 +87,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, ResourceLocation lootTable) {
         try {
-            rawRegisters.put(new MobEntry(entity), lootTable);
+            rawRegisters.put(MobEntry.create(() -> entity), lootTable);
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -98,7 +98,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, int minExp, int maxExp, String[] biomes, LootDrop... lootDrops) {
         try {
-            preppedRegisters.add(new MobEntry(entity, lightLevel, minExp, maxExp, biomes, lootDrops));
+            preppedRegisters.add(MobEntry.create(() -> entity, lightLevel, minExp, maxExp, biomes, lootDrops));
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -107,7 +107,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, int minExp, int maxExp, LootDrop... lootDrops) {
         try {
-            preppedRegisters.add(new MobEntry(entity, lightLevel, minExp, maxExp, lootDrops));
+            preppedRegisters.add(MobEntry.create(() -> entity, lightLevel, minExp, maxExp, lootDrops));
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -116,7 +116,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, int exp, String[] biomes, LootDrop... lootDrops) {
         try {
-            preppedRegisters.add(new MobEntry(entity, lightLevel, exp, biomes, lootDrops));
+            preppedRegisters.add(MobEntry.create(() -> entity, lightLevel, exp, biomes, lootDrops));
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -125,7 +125,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, int exp, LootDrop... lootDrops) {
         try {
-            preppedRegisters.add(new MobEntry(entity, lightLevel, exp, lootDrops));
+            preppedRegisters.add(MobEntry.create(() -> entity, lightLevel, exp, lootDrops));
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -134,7 +134,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, String[] biomes, LootDrop... lootDrops) {
         try {
-            preppedRegisters.add(new MobEntry(entity, lightLevel, biomes, lootDrops));
+            preppedRegisters.add(MobEntry.create(() -> entity, lightLevel, biomes, lootDrops));
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -143,7 +143,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LightLevel lightLevel, LootDrop... lootDrops) {
         try {
-            preppedRegisters.add(new MobEntry(entity, lightLevel, lootDrops));
+            preppedRegisters.add(MobEntry.create(() -> entity, lightLevel, lootDrops));
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -152,7 +152,7 @@ public class MobRegistryImpl implements IMobRegistry {
     @Override
     public void register(LivingEntity entity, LootDrop... lootDrops) {
         try {
-            preppedRegisters.add(new MobEntry(entity, lootDrops));
+            preppedRegisters.add(MobEntry.create(() -> entity, lootDrops));
         } catch (Exception e) {
             LogHelper.debug("Bad mob register for %s", entity.getClass().getName());
         }
@@ -201,7 +201,7 @@ public class MobRegistryImpl implements IMobRegistry {
     protected static void commit() {
         preppedRegisters.forEach(MobRegistry.getInstance()::registerMob);
         Level level = CompatBase.getLevel();
-        rawRegisters.forEach((key, value) -> key.addDrops(LootTableHelper.toDrops(level, value)));
+        rawRegisters.forEach((key, value) -> key.setDrops(LootTableHelper.toDrops(level, value)));
         rawRegisters.keySet().forEach(MobRegistry.getInstance()::registerMob);
     }
 }

--- a/src/main/java/jeresources/compatibility/minecraft/ExperienceRange.java
+++ b/src/main/java/jeresources/compatibility/minecraft/ExperienceRange.java
@@ -1,0 +1,19 @@
+package jeresources.compatibility.minecraft;
+
+public class ExperienceRange {
+    public static final ExperienceRange ZERO = new ExperienceRange(0, 0);
+
+    public final int min;
+    public final int max;
+
+    public ExperienceRange(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public String getExpString() {
+        if (this.max == this.min)
+            return Integer.toString(this.min);
+        return this.min + " - " + this.max;
+    }
+}

--- a/src/main/java/jeresources/compatibility/minecraft/ExperienceRange.java
+++ b/src/main/java/jeresources/compatibility/minecraft/ExperienceRange.java
@@ -1,15 +1,7 @@
 package jeresources.compatibility.minecraft;
 
-public class ExperienceRange {
+public record ExperienceRange(int min, int max) {
     public static final ExperienceRange ZERO = new ExperienceRange(0, 0);
-
-    public final int min;
-    public final int max;
-
-    public ExperienceRange(int min, int max) {
-        this.min = min;
-        this.max = max;
-    }
 
     public String getExpString() {
         if (this.max == this.min)

--- a/src/main/java/jeresources/compatibility/minecraft/MinecraftCompat.java
+++ b/src/main/java/jeresources/compatibility/minecraft/MinecraftCompat.java
@@ -1,6 +1,6 @@
 package jeresources.compatibility.minecraft;
 
-import java.util.Comparator;
+import java.util.Map;
 
 import jeresources.api.conditionals.Conditional;
 import jeresources.api.distributions.DistributionSquare;
@@ -39,19 +39,12 @@ public class MinecraftCompat extends CompatBase {
         registerVanillaPlants();
     }
 
-    @Override
-    protected void registerMob(MobEntry entry) {
-        MobCompat.getInstance().setLightLevel(entry);
-        MobCompat.getInstance().setExperience(entry);
-        super.registerMob(entry);
-    }
-
     private void registerVanillaMobs() {
         Level level = getLevel();
         LootTables lootTables = LootTableHelper.getLootTables(level);
         LootTableHelper.getAllMobLootTables(level).entrySet().stream()
-            .map(entry -> new MobEntry(entry.getValue(), lootTables.get(entry.getKey())))
-            .sorted(Comparator.comparing(MobEntry::getMobName))
+            .sorted(Map.Entry.comparingByKey())
+            .map(entry -> MobEntry.create(entry.getValue(), lootTables.get(entry.getKey())))
             .forEach(this::registerMob);
 
         registerMobRenderHook(Bat.class, RenderHooks.BAT);

--- a/src/main/java/jeresources/compatibility/minecraft/MobCompat.java
+++ b/src/main/java/jeresources/compatibility/minecraft/MobCompat.java
@@ -1,106 +1,64 @@
 package jeresources.compatibility.minecraft;
 
-import java.util.HashMap;
-
 import jeresources.api.conditionals.LightLevel;
-import jeresources.entry.MobEntry;
-import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ambient.Bat;
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.animal.WaterAnimal;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
-import net.minecraft.world.entity.monster.*;
-import net.minecraft.world.level.Level;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.world.entity.monster.Blaze;
+import net.minecraft.world.entity.monster.Guardian;
+import net.minecraft.world.entity.monster.MagmaCube;
+import net.minecraft.world.entity.monster.Monster;
+import net.minecraft.world.entity.monster.PatrollingMonster;
+import net.minecraft.world.entity.monster.Phantom;
+import net.minecraft.world.entity.monster.Slime;
+import net.minecraft.world.entity.monster.Vex;
+import net.minecraft.world.entity.monster.Witch;
 
 public class MobCompat {
-    private static Level level = MinecraftCompat.getLevel();
-    private final HashMap<Class, Tuple<Integer, Integer>> MOB_XP = new HashMap<>();
-    private final HashMap<Class, LightLevel> LIGHT_LEVEL = new HashMap<>();
-    private static MobCompat instance;
+    private MobCompat() {}
 
-    public static MobCompat getInstance() {
-        if (instance == null)
-            return instance = new MobCompat();
-        return instance;
-    }
-
-    private MobCompat() {
-        initMobXp();
-        initLightLevel();
-    }
-
-    public void setLightLevel(MobEntry entry) {
-        Class entityClass = entry.getEntity().getClass();
-        
-        entry.setLightLevel(LIGHT_LEVEL.getOrDefault(entityClass, LightLevel.any));
-    }
-
-    public void setExperience(MobEntry entry) {
-        Class entityClass = entry.getEntity().getClass();
-
-        Tuple<Integer, Integer> minMaxExp = MOB_XP.getOrDefault(entityClass, new Tuple<>(0,0));
-
-        entry.setMinExp(minMaxExp.getA());
-        entry.setMaxExp(minMaxExp.getB());
-    }
-
-    private void initMobXp() {
-        for (EntityType entityType : ForgeRegistries.ENTITIES) {
-            Entity entity = entityType.create(level);
-
-            if (entity instanceof Mob) {
-                Class entityClass = entity.getClass();
-                Tuple<Integer, Integer> exp;
-
-                if(entity instanceof Animal || entity instanceof WaterAnimal) {
-                    exp = new Tuple<>(1, 3);
-                }
-                else if(entity instanceof EnderDragon) {
-                    exp = new Tuple<>(500, 12000);
-                }
-                else if(entity instanceof Slime || entity instanceof MagmaCube) {
-                    exp = new Tuple<>(1, 4);
-                }
-                else {
-                    exp = new Tuple<>(((Mob)entity).xpReward, ((Mob)entity).xpReward);
-                }
-
-                MOB_XP.put(entityClass, exp);
+    public static ExperienceRange getExperience(LivingEntity entity) {
+        if(entity instanceof Mob) {
+            if(entity instanceof Animal || entity instanceof WaterAnimal) {
+                return new ExperienceRange(1, 3);
+            }
+            else if(entity instanceof EnderDragon) {
+                return new ExperienceRange(500, 12000);
+            }
+            else if(entity instanceof Slime || entity instanceof MagmaCube) {
+                return new ExperienceRange(1, 4);
+            }
+            else {
+                int xp = ((Mob)entity).xpReward;
+                return new ExperienceRange(xp, xp);
             }
         }
+        return ExperienceRange.ZERO;
     }
 
-    private void initLightLevel() {
-        for (EntityType entityType : ForgeRegistries.ENTITIES) {
-            Entity entity = entityType.create(level);
-
-            if (entity instanceof Mob) {
-                Class entityClass = entity.getClass();
-
-                if (cannotSpawnNaturally(entity)) {
-                    LIGHT_LEVEL.put(entityClass, LightLevel.any);
-                }
-                else if (entity instanceof Blaze) {
-                    LIGHT_LEVEL.put(entityClass, LightLevel.blaze);
-                }
-                else if (entity instanceof Monster || entity instanceof Slime || entity instanceof Phantom) {
-                    LIGHT_LEVEL.put(entityClass, LightLevel.hostile);
-                }
-                else if (entity instanceof Bat) {
-                    LIGHT_LEVEL.put(entityClass, LightLevel.bat);
-                }
-                else {
-                    LIGHT_LEVEL.put(entityClass, LightLevel.any);
-                }
+    public static LightLevel getLightLevel(Entity entity) {
+        if (entity instanceof Mob) {
+            if (cannotSpawnNaturally(entity)) {
+                return LightLevel.any;
+            }
+            else if (entity instanceof Blaze) {
+                return LightLevel.blaze;
+            }
+            else if (entity instanceof Monster || entity instanceof Slime || entity instanceof Phantom) {
+                return LightLevel.hostile;
+            }
+            else if (entity instanceof Bat) {
+                return LightLevel.bat;
             }
         }
+        return LightLevel.any;
     }
 
-    private boolean cannotSpawnNaturally(Entity entity) {
+    private static boolean cannotSpawnNaturally(Entity entity) {
         return entity instanceof Vex || entity instanceof Guardian || (entity instanceof PatrollingMonster && !(entity instanceof Witch));
     }
 }

--- a/src/main/java/jeresources/entry/VillagerEntry.java
+++ b/src/main/java/jeresources/entry/VillagerEntry.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.item.ItemStack;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -18,6 +19,8 @@ import java.util.stream.Collectors;
 public class VillagerEntry {
     private final List<TradeList> tradeList;
     private final VillagerProfession profession;
+    @Nullable
+    private Villager entity;
 
     public VillagerEntry(VillagerProfession profession, Int2ObjectMap<VillagerTrades.ItemListing[]> itemListings) {
         this.profession = profession;
@@ -86,9 +89,12 @@ public class VillagerEntry {
     }
 
     public Villager getVillagerEntity() {
-        Villager villager = EntityType.VILLAGER.create(CompatBase.getLevel());
-        villager.setVillagerData(villager.getVillagerData().setProfession(this.profession));
-        return villager;
+        if (this.entity == null) {
+            this.entity = EntityType.VILLAGER.create(CompatBase.getLevel());
+            assert this.entity != null;
+            this.entity.setVillagerData(this.entity.getVillagerData().setProfession(this.profession));
+        }
+        return this.entity;
     }
 
     public List<ItemStack> getPois() {

--- a/src/main/java/jeresources/jei/mob/MobCategory.java
+++ b/src/main/java/jeresources/jei/mob/MobCategory.java
@@ -1,17 +1,20 @@
 package jeresources.jei.mob;
 
+import jeresources.api.drop.LootDrop;
 import jeresources.config.Settings;
 import jeresources.jei.BlankJEIRecipeCategory;
 import jeresources.jei.JEIConfig;
 import jeresources.reference.Resources;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
 import mezz.jei.api.ingredients.IIngredients;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 public class MobCategory extends BlankJEIRecipeCategory<MobWrapper> {
     protected static final int X_FIRST_ITEM = 97;
@@ -39,6 +42,7 @@ public class MobCategory extends BlankJEIRecipeCategory<MobWrapper> {
         return Resources.Gui.Jei.MOB;
     }
 
+    @Nonnull
     @Override
     public Class<? extends MobWrapper> getRecipeClass() {
         return MobWrapper.class;
@@ -46,19 +50,26 @@ public class MobCategory extends BlankJEIRecipeCategory<MobWrapper> {
 
     @Override
     public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull MobWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+
         int xOffset = 0;
         int slot = 0;
         for (int i = 0; i < Settings.ITEMS_PER_ROW; i++) {
             int yOffset = 0;
             for (int ii = 0; ii < Settings.ITEMS_PER_COLUMN; ii++) {
-                recipeLayout.getItemStacks().init(slot++, false, X_FIRST_ITEM + xOffset, Y_FIRST_ITEM + yOffset);
+                itemStacks.init(slot++, false, X_FIRST_ITEM + xOffset, Y_FIRST_ITEM + yOffset);
                 yOffset += 80 / Settings.ITEMS_PER_COLUMN;
             }
             xOffset += 72 / Settings.ITEMS_PER_ROW;
         }
 
-        recipeLayout.getItemStacks().addTooltipCallback(recipeWrapper);
-        for (int i = 0; i < Math.min(recipeWrapper.getDrops().length, Settings.ITEMS_PER_ROW * Settings.ITEMS_PER_COLUMN); i++)
-            recipeLayout.getItemStacks().set(i, recipeWrapper.getDrops()[i].getDrops());
+        itemStacks.addTooltipCallback(recipeWrapper);
+
+        List<LootDrop> drops = recipeWrapper.getDrops();
+        int dropCount = Math.min(drops.size(), Settings.ITEMS_PER_ROW * Settings.ITEMS_PER_COLUMN);
+        for (int i = 0; i < dropCount; i++) {
+            LootDrop lootDrop = drops.get(i);
+            itemStacks.set(i, lootDrop.getDrops());
+        }
     }
 }

--- a/src/main/java/jeresources/util/CollectionHelper.java
+++ b/src/main/java/jeresources/util/CollectionHelper.java
@@ -5,9 +5,11 @@ import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CollectionHelper {
     public static List<ItemStack> create(ItemStack... itemStacks) {
@@ -18,7 +20,7 @@ public class CollectionHelper {
         return new ArrayList<>(Arrays.asList(strings));
     }
 
-    public static List<Component> create(Function<String, Component> function, String... strings) {
-        return new ArrayList<>(Arrays.asList(strings)).stream().map(function).collect(Collectors.toList());
+    public static List<Component> create(Function<String, Component> function, Stream<String> strings) {
+        return strings.map(function).collect(Collectors.toList());
     }
 }

--- a/src/main/java/jeresources/util/LootTableHelper.java
+++ b/src/main/java/jeresources/util/LootTableHelper.java
@@ -28,6 +28,7 @@ import net.minecraftforge.resource.PathResourcePack;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 public class LootTableHelper {
     private static final Map<DyeColor, ResourceLocation> sheepColors = new HashMap<>();
@@ -143,7 +144,7 @@ public class LootTableHelper {
         return chestTables;
     }
 
-    public static Map<ResourceLocation, LivingEntity> getAllMobLootTables(Level world) {
+    public static Map<ResourceLocation, Supplier<LivingEntity>> getAllMobLootTables(Level world) {
         MobTableBuilder mobTableBuilder = new MobTableBuilder(world);
 
         for (Map.Entry<DyeColor, ResourceLocation> entry : sheepColors.entrySet()) {
@@ -152,7 +153,7 @@ public class LootTableHelper {
             mobTableBuilder.addSheep(lootTableList, EntityType.SHEEP, dyeColor);
         }
 
-        for (EntityType entityType : ForgeRegistries.ENTITIES) {
+        for (EntityType<?> entityType : ForgeRegistries.ENTITIES) {
             if (entityType.getCategory() != MobCategory.MISC && entityType != EntityType.SHEEP) {
                 mobTableBuilder.add(entityType.getDefaultLootTable(), entityType);
             }

--- a/src/main/java/jeresources/util/MobHelper.java
+++ b/src/main/java/jeresources/util/MobHelper.java
@@ -1,23 +1,19 @@
 package jeresources.util;
 
-import jeresources.entry.MobEntry;
-import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.Sheep;
+import org.apache.commons.lang3.text.WordUtils;
 
 public class MobHelper {
-    public static int getExpDrop(MobEntry entry) {
-        if (entry.getEntity() instanceof Mob)
-            return ((Mob)entry.getEntity()).xpReward;
-        return 0;
-    }
+    public static String getExpandedName(LivingEntity entity) {
+        String expandedName = entity.getName().getString();
 
-    public static String getExpandedName(MobEntry entry) {
-        String raw = entry.getEntity().getName().getString();
-        if (entry.getEntity() instanceof Sheep)
-            raw += " (" + TranslationHelper.translateAndFormat("color.minecraft."+((Sheep) entry.getEntity()).getColor().getName()) + ")";
-        StringBuilder sb = new StringBuilder();
-        for (String s : raw.split(" "))
-            sb.append(s.substring(0, 1).toUpperCase()).append(s.substring(1)).append(" ");
-        return sb.toString().trim();
+        if (entity instanceof Sheep sheep) {
+            String colorNameKey = String.format("color.minecraft.%s", sheep.getColor().getName());
+            String localizedColorName = TranslationHelper.translateAndFormat(colorNameKey);
+            expandedName = String.format("%s (%s)", expandedName, localizedColorName);
+        }
+
+        return WordUtils.capitalize(expandedName);
     }
 }

--- a/src/main/java/jeresources/util/MobTableBuilder.java
+++ b/src/main/java/jeresources/util/MobTableBuilder.java
@@ -7,8 +7,8 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.Sheep;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.Level;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -45,7 +45,7 @@ public class MobTableBuilder {
     /** Helper class to allow public access to EntityLoot.isNonLiving */
     private static class MyEntityLoot extends EntityLoot {
         @Override
-        public boolean isNonLiving(@NotNull EntityType<?> entitytype) {
+        public boolean isNonLiving(@Nonnull EntityType<?> entitytype) {
             return super.isNonLiving(entitytype);
         }
     }

--- a/src/main/java/jeresources/util/MobTableBuilder.java
+++ b/src/main/java/jeresources/util/MobTableBuilder.java
@@ -1,18 +1,22 @@
 package jeresources.util;
 
+import net.minecraft.data.loot.EntityLoot;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.Sheep;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 public class MobTableBuilder {
-    private final Map<ResourceLocation, LivingEntity> mobTables = new HashMap<>();
+    private final Map<ResourceLocation, Supplier<LivingEntity>> mobTables = new ConcurrentHashMap<>();
+    private final MyEntityLoot entityLootHelper = new MyEntityLoot();
     private final Level level;
 
     public MobTableBuilder(Level level) {
@@ -20,25 +24,30 @@ public class MobTableBuilder {
     }
 
     public void add(ResourceLocation resourceLocation, EntityType<?> entityType) {
-        Entity entity = entityType.create(level);
-        if (entity instanceof LivingEntity) {
-            mobTables.put(resourceLocation, (LivingEntity) entity);
-        } else {
-            if (entity != null) {
-                entity.remove(Entity.RemovalReason.DISCARDED);
-            }
+        if (entityLootHelper.isNonLiving(entityType)) {
+            return;
         }
+        mobTables.put(resourceLocation, () -> (LivingEntity) entityType.create(level));
     }
 
     public void addSheep(ResourceLocation resourceLocation, EntityType<Sheep> entityType, DyeColor dye) {
-        Sheep sheep = entityType.create(level);
-        if (sheep != null) {
+        mobTables.put(resourceLocation, () -> {
+            Sheep sheep = entityType.create(level);
+            assert sheep != null;
             sheep.setColor(dye);
-            mobTables.put(resourceLocation, sheep);
-        }
+            return sheep;
+        });
     }
 
-    public Map<ResourceLocation, LivingEntity> getMobTables() {
+    public Map<ResourceLocation, Supplier<LivingEntity>> getMobTables() {
         return mobTables;
+    }
+
+    /** Helper class to allow public access to EntityLoot.isNonLiving */
+    private static class MyEntityLoot extends EntityLoot {
+        @Override
+        public boolean isNonLiving(@NotNull EntityType<?> entitytype) {
+            return super.isNonLiving(entitytype);
+        }
     }
 }

--- a/src/main/java/jeresources/util/MobTableBuilder.java
+++ b/src/main/java/jeresources/util/MobTableBuilder.java
@@ -11,11 +11,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 public class MobTableBuilder {
-    private final Map<ResourceLocation, Supplier<LivingEntity>> mobTables = new ConcurrentHashMap<>();
+    private final Map<ResourceLocation, Supplier<LivingEntity>> mobTables = new HashMap<>();
     private final MyEntityLoot entityLootHelper = new MyEntityLoot();
     private final Level level;
 


### PR DESCRIPTION
Hey way2muchnoise!
I did some profiling on JER and found it was spending a lot of time loading loot tables on singleplayer, and creating entities.

This PR:
* makes most entity loading lazy, so they are only created when showing the recipes
* avoids creating 100 villager entities for each trade
* loads loot tables from the singleplayer level instance if you're loading a local world

All these took loading time on singleplayer for the ATM7 mod pack from 3.5ish seconds down to 150ms on my computer.