### PR TITLE
Only use ServerLevel for loot table loading, Fix #325 and #326

### DIFF
--- a/src/main/java/jeresources/compatibility/CompatBase.java
+++ b/src/main/java/jeresources/compatibility/CompatBase.java
@@ -11,28 +11,35 @@ import jeresources.registry.PlantRegistry;
 import jeresources.registry.WorldGenRegistry;
 import jeresources.util.FakeClientLevel;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.server.IntegratedServer;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 public abstract class CompatBase {
     @Nullable
     private static Level fakeClientLevel = null;
 
+    /**
+     * This should only be used for loading loot tables,
+     * it is used so that clients connected to an integrated server
+     * do not need to load the loot tables multiple times.
+     *
+     * It is dangerous to use for other purposes, because modded entities (and even vanilla villagers)
+     * can load lots of things if they have the server level, which will make JER load slowly.
+     */
+    public static Optional<Level> getServerLevel() {
+        Minecraft minecraft = Minecraft.getInstance();
+        return Optional.of(minecraft)
+                .map(Minecraft::getSingleplayerServer)
+                .map(integratedServer -> integratedServer.getLevel(Level.OVERWORLD));
+    }
+
+    @Nonnull
     public static Level getLevel() {
         Minecraft minecraft = Minecraft.getInstance();
-        IntegratedServer integratedServer = minecraft.getSingleplayerServer();
-
-        if (integratedServer != null) {
-            ServerLevel serverLevel = integratedServer.getLevel(Level.OVERWORLD);
-            if (serverLevel != null) {
-                return serverLevel;
-            }
-        }
-
         Level level = minecraft.level;
         if (level != null) {
             return level;

--- a/src/main/java/jeresources/compatibility/DungeonRegistryImpl.java
+++ b/src/main/java/jeresources/compatibility/DungeonRegistryImpl.java
@@ -7,7 +7,6 @@ import jeresources.util.LogHelper;
 import jeresources.util.LootTableHelper;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Tuple;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.LootTables;
 
@@ -48,8 +47,7 @@ public class DungeonRegistryImpl implements IDungeonRegistry {
     protected static void commit() {
         categoryMapping.forEach(t -> DungeonRegistry.addCategoryMapping(t.getA(), t.getB()));
         preppedRegisters.forEach(entry -> DungeonRegistry.getInstance().registerDungeonEntry(entry));
-        Level level = CompatBase.getLevel();
-        LootTables manager = LootTableHelper.getLootTables(level);
+        LootTables manager = LootTableHelper.getLootTables();
         rawRegisters.entrySet().stream()
             .map(entry -> {
                 try {

--- a/src/main/java/jeresources/compatibility/MobRegistryImpl.java
+++ b/src/main/java/jeresources/compatibility/MobRegistryImpl.java
@@ -200,8 +200,7 @@ public class MobRegistryImpl implements IMobRegistry {
 
     protected static void commit() {
         preppedRegisters.forEach(MobRegistry.getInstance()::registerMob);
-        Level level = CompatBase.getLevel();
-        rawRegisters.forEach((key, value) -> key.setDrops(LootTableHelper.toDrops(level, value)));
+        rawRegisters.forEach((key, value) -> key.setDrops(LootTableHelper.toDrops(value)));
         rawRegisters.keySet().forEach(MobRegistry.getInstance()::registerMob);
     }
 }

--- a/src/main/java/jeresources/compatibility/minecraft/MinecraftCompat.java
+++ b/src/main/java/jeresources/compatibility/minecraft/MinecraftCompat.java
@@ -40,9 +40,8 @@ public class MinecraftCompat extends CompatBase {
     }
 
     private void registerVanillaMobs() {
-        Level level = getLevel();
-        LootTables lootTables = LootTableHelper.getLootTables(level);
-        LootTableHelper.getAllMobLootTables(level).entrySet().stream()
+        LootTables lootTables = LootTableHelper.getLootTables();
+        LootTableHelper.getAllMobLootTables().entrySet().stream()
             .sorted(Map.Entry.comparingByKey())
             .map(entry -> MobEntry.create(entry.getValue(), lootTables.get(entry.getKey())))
             .forEach(this::registerMob);
@@ -57,8 +56,7 @@ public class MinecraftCompat extends CompatBase {
     }
 
     private void registerDungeonLoot() {
-        Level level = getLevel();
-        LootTables lootTables = LootTableHelper.getLootTables(level);
+        LootTables lootTables = LootTableHelper.getLootTables();
         LootTableHelper.getAllChestLootTablesResourceLocations().stream()
             .map(resourceLocation -> new DungeonEntry(resourceLocation.getPath(), lootTables.get(resourceLocation)))
             .forEach(this::registerDungeonEntry);

--- a/src/main/java/jeresources/entry/VillagerEntry.java
+++ b/src/main/java/jeresources/entry/VillagerEntry.java
@@ -90,6 +90,11 @@ public class VillagerEntry {
 
     public Villager getVillagerEntity() {
         if (this.entity == null) {
+            /*
+             * level must be a client level here.
+             * Passing in a ServerLevel can allow villagers to load all kinds of things,
+             * like in the `VillagerTrades.TreasureMapForEmeralds` which loads chunks!
+             */
             this.entity = EntityType.VILLAGER.create(CompatBase.getLevel());
             assert this.entity != null;
             this.entity.setVillagerData(this.entity.getVillagerData().setProfession(this.profession));

--- a/src/main/java/jeresources/util/LootTableHelper.java
+++ b/src/main/java/jeresources/util/LootTableHelper.java
@@ -25,7 +25,6 @@ import net.minecraftforge.forgespi.language.IModFileInfo;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.resource.PathResourcePack;
 
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -94,8 +93,8 @@ public class LootTableHelper {
         return drops;
     }
 
-    public static List<LootDrop> toDrops(Level level, ResourceLocation lootTable) {
-        return toDrops(getLootTables(level).get(lootTable));
+    public static List<LootDrop> toDrops(ResourceLocation lootTable) {
+        return toDrops(getLootTables().get(lootTable));
     }
 
     public static List<ResourceLocation> getAllChestLootTablesResourceLocations() {
@@ -144,8 +143,8 @@ public class LootTableHelper {
         return chestTables;
     }
 
-    public static Map<ResourceLocation, Supplier<LivingEntity>> getAllMobLootTables(Level world) {
-        MobTableBuilder mobTableBuilder = new MobTableBuilder(world);
+    public static Map<ResourceLocation, Supplier<LivingEntity>> getAllMobLootTables() {
+        MobTableBuilder mobTableBuilder = new MobTableBuilder();
 
         for (Map.Entry<DyeColor, ResourceLocation> entry : sheepColors.entrySet()) {
             ResourceLocation lootTableList = entry.getValue();
@@ -164,8 +163,10 @@ public class LootTableHelper {
 
     private static LootTables lootTables;
 
-    public static LootTables getLootTables(@Nullable Level level) {
-        if (level == null || level.getServer() == null) {
+    public static LootTables getLootTables() {
+        Level level = CompatBase.getServerLevel()
+                .orElseGet(CompatBase::getLevel);
+        if (level.getServer() == null) {
             if (lootTables == null) {
                 lootTables = new LootTables(new PredicateManager());
 
@@ -187,9 +188,5 @@ public class LootTableHelper {
             return lootTables;
         }
         return level.getServer().getLootTables();
-    }
-
-    public static LootTables getLootTables() {
-        return getLootTables(CompatBase.getLevel());
     }
 }

--- a/src/main/java/jeresources/util/MobTableBuilder.java
+++ b/src/main/java/jeresources/util/MobTableBuilder.java
@@ -1,5 +1,6 @@
 package jeresources.util;
 
+import jeresources.compatibility.CompatBase;
 import net.minecraft.data.loot.EntityLoot;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
@@ -16,10 +17,15 @@ import java.util.function.Supplier;
 public class MobTableBuilder {
     private final Map<ResourceLocation, Supplier<LivingEntity>> mobTables = new HashMap<>();
     private final MyEntityLoot entityLootHelper = new MyEntityLoot();
+    /**
+     * level should be a client level.
+     * Passing in a ServerLevel can allow modded mobs to load all kinds of things,
+     * like in the `VillagerTrades.TreasureMapForEmeralds` which loads chunks!
+     */
     private final Level level;
 
-    public MobTableBuilder(Level level) {
-        this.level = level;
+    public MobTableBuilder() {
+        this.level = CompatBase.getLevel();
     }
 
     public void add(ResourceLocation resourceLocation, EntityType<?> entityType) {


### PR DESCRIPTION
Villagers have a trade that will load chunks if they have access to the ServerLevel,
`net.minecraft.world.entity.npc.VillagerTrades.TreasureMapForEmeralds#getOffer`
```java
if (!(p_35817_.level instanceof ServerLevel)) {
            return null;
```
So in my previous PR that uses the ServerLevel, it introduced a big slowdown because the villager trades were really loading a lot of stuff.

This PR makes sure the ServerLevel is only used for LootTable and everything else gets a ClientLevel like before.