### PR TITLE
Executes the builds much more quickly by Gradle Daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,5 @@ version_revis=0
 version_jei=9.4.1.106
 curse_project_id=240630
 repo=way2muchnoise/JustEnoughResources
-org.gradle.daemon=false
+org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx3G


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
