### PR TITLE
Address issue with missing lang key "jer.magmaCream.text"

### DIFF
--- a/src/main/resources/assets/jeresources/lang/de_de.json
+++ b/src/main/resources/assets/jeresources/lang/de_de.json
@@ -102,7 +102,7 @@
 	"_comment": "#Villager View",
 	"jer.villager.title": "Dorfbewohnerangebote",
 
-	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string\"jer.magmaCream.text\": \"Small and Large Magma Cubes\",",
+	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string",
 	"jer.slimeBall.text": "Nur kleine Schleime",
 	"jer.rareDrop.text": "Seltener Drop",
 

--- a/src/main/resources/assets/jeresources/lang/en_us.json
+++ b/src/main/resources/assets/jeresources/lang/en_us.json
@@ -105,7 +105,8 @@
 	"jer.villager.title": "Villager Trades",
 	"jer.villager.poi": "Point of Interest",
 
-	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string\"jer.magmaCream.text\": \"Small and Large Magma Cubes\",",
+	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string",
+	"jer.magmaCream.text": "Small and Large Magma Cubes",
 	"jer.slimeBall.text": "Tiny Slimes only",
 	"jer.rareDrop.text": "Rare Drop",
 

--- a/src/main/resources/assets/jeresources/lang/es_es.json
+++ b/src/main/resources/assets/jeresources/lang/es_es.json
@@ -105,7 +105,7 @@
 	"jer.villager.title": "Comercios de aldeanos",
 	"jer.villager.poi": "Punto de interés",
 
-	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string\"jer.magmaCream.text\": \"Small and Large Magma Cubes\",",
+	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string",
 	"jer.slimeBall.text": "Solo slimes pequeños",
 	"jer.rareDrop.text": "Obtención rara",
 

--- a/src/main/resources/assets/jeresources/lang/fr_fr.json
+++ b/src/main/resources/assets/jeresources/lang/fr_fr.json
@@ -105,7 +105,7 @@
 	"jer.villager.title": "Echanges villageois",
 	"jer.villager.poi": "Point d'intérêt",
 
-	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string\"jer.magmaCream.text\": \"Small and Large Magma Cubes\",",
+	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string",
 	"jer.slimeBall.text": "Slimes minuscules uniquement",
 	"jer.rareDrop.text": "Butin rare",
 

--- a/src/main/resources/assets/jeresources/lang/it_it.json
+++ b/src/main/resources/assets/jeresources/lang/it_it.json
@@ -105,7 +105,7 @@
 	"jer.villager.title": "Commercio con i Villici",
 	"jer.villager.poi": "Punto di interesse",
 
-	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string\"jer.magmaCream.text\": \"Small and Large Magma Cubes\",",
+	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string",
 	"jer.slimeBall.text": "Slime piccoli soltanto",
 	"jer.rareDrop.text": "Ottenimento raro",
 

--- a/src/main/resources/assets/jeresources/lang/ko_kr.json
+++ b/src/main/resources/assets/jeresources/lang/ko_kr.json
@@ -105,7 +105,7 @@
 	"jer.villager.title": "주민 거래",
 	"jer.villager.poi": "관심점",
 
-	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string\"jer.magmaCream.text\": \"Small and Large Magma Cubes\",",
+	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string",
 	"jer.slimeBall.text": "가장 작은 슬라임 전용",
 	"jer.rareDrop.text": "희귀 드랍",
 

--- a/src/main/resources/assets/jeresources/lang/nl_nl.json
+++ b/src/main/resources/assets/jeresources/lang/nl_nl.json
@@ -43,7 +43,8 @@
 	"jer.mob.biome": "Spawn Biomes: Hover muis hier",
 	"jer.mob.exp": "Experience Dropped",
 
-	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string\"jer.magmaCream.text\": \"Grote en kleine Magma Cubes\",",
+	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string",
+	"jer.magmaCream.text": "Grote en kleine Magma Cubes",
 	"jer.slimeBall.text": "Alleen kleine slimes",
 	"jer.rareDrop.text": "Zeldzame Drop",
 

--- a/src/main/resources/assets/jeresources/lang/zh_tw.json
+++ b/src/main/resources/assets/jeresources/lang/zh_tw.json
@@ -102,7 +102,7 @@
 	"_comment": "#Villager View",
 	"jer.villager.title": "村民交易",
 
-	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string\"jer.magmaCream.text\": \"Small and Large Magma Cubes\",",
+	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string",
 	"jer.slimeBall.text": "僅小型史萊姆掉落",
 	"jer.rareDrop.text": "稀有掉落物",
 


### PR DESCRIPTION
It seems like when the [lang files were converted to JSON](https://github.com/way2muchnoise/JustEnoughResources/commit/e381babd59258cdf24dba5362710be7b21021f4b) `jer.magmaCream.text` got incorrectly incorporated into a comment and propagated out to a number of different language files.

I've removed the erroneous trailing comment text and restored the key to the language files where a translation was available.