### PR TITLE
Add support for Wandering Trader

### DIFF
--- a/Common/src/main/java/jeresources/collection/TradeList.java
+++ b/Common/src/main/java/jeresources/collection/TradeList.java
@@ -1,8 +1,8 @@
 package jeresources.collection;
 
-import jeresources.entry.VillagerEntry;
 import mezz.jei.api.recipe.IFocus;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.npc.AbstractVillager;
 import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.trading.MerchantOffer;
@@ -16,10 +16,10 @@ import java.util.stream.Collectors;
 public class TradeList extends LinkedList<TradeList.Trade> {
     private static final Random r = new Random();
 
-    private VillagerEntry villagerEntry;
+    private AbstractVillager entity;
 
-    public TradeList(VillagerEntry villagerEntry) {
-        this.villagerEntry = villagerEntry;
+    public TradeList(AbstractVillager entity) {
+        this.entity = entity;
     }
 
     public List<ItemStack> getCostAs() {
@@ -35,11 +35,11 @@ public class TradeList extends LinkedList<TradeList.Trade> {
     }
 
     public TradeList getSubListSell(ItemStack itemStack) {
-        return this.stream().filter(trade -> trade.sellsItem(itemStack)).collect(Collectors.toCollection(() -> new TradeList(villagerEntry)));
+        return this.stream().filter(trade -> trade.sellsItem(itemStack)).collect(Collectors.toCollection(() -> new TradeList(entity)));
     }
 
     public TradeList getSubListBuy(ItemStack itemStack) {
-        return this.stream().filter(trade -> trade.buysItem(itemStack)).collect(Collectors.toCollection(() -> new TradeList(villagerEntry)));
+        return this.stream().filter(trade -> trade.buysItem(itemStack)).collect(Collectors.toCollection(() -> new TradeList(entity)));
     }
 
     public TradeList getFocusedList(IFocus<ItemStack> focus) {
@@ -55,7 +55,7 @@ public class TradeList extends LinkedList<TradeList.Trade> {
     }
 
     private void addMerchantRecipe(MerchantOffers merchantOffers, VillagerTrades.ItemListing itemListing, RandomSource rand) {
-        MerchantOffer offer = itemListing.getOffer(villagerEntry.getVillagerEntity(), rand);
+        MerchantOffer offer = itemListing.getOffer(entity, rand);
         if (offer != null) {
             merchantOffers.add(offer);
         }

--- a/Common/src/main/java/jeresources/entry/AbstractVillagerEntry.java
+++ b/Common/src/main/java/jeresources/entry/AbstractVillagerEntry.java
@@ -45,8 +45,9 @@ public abstract class AbstractVillagerEntry<T extends AbstractVillager> {
         for (List<TradeList.Trade> trades : this.tradeList) {
             for (TradeList.Trade trade : trades) {
                 list.add(trade.getMinCostA());
-                if (!trade.getMinCostB().isEmpty())
+                if (!trade.getMinCostB().isEmpty()) {
                     list.add(trade.getMinCostB());
+                }
             }
         }
         return list;
@@ -54,8 +55,9 @@ public abstract class AbstractVillagerEntry<T extends AbstractVillager> {
 
     public List<ItemStack> getOutputs() {
         List<ItemStack> list = new LinkedList<>();
-        for (List<TradeList.Trade> trades : this.tradeList)
+        for (List<TradeList.Trade> trades : this.tradeList) {
             list.addAll(trades.stream().map(TradeList.Trade::getMinResult).collect(Collectors.toList()));
+        }
         return list;
     }
 
@@ -69,9 +71,11 @@ public abstract class AbstractVillagerEntry<T extends AbstractVillager> {
 
     public List<Integer> getPossibleLevels(IFocus<ItemStack> focus) {
         List<Integer> levels = new ArrayList<>();
-        for (int i = 0; i < tradeList.size(); i++)
-            if (tradeList.get(i) != null && tradeList.get(i).getFocusedList(focus).size() > 0)
+        for (int i = 0; i < tradeList.size(); i++) {
+            if (tradeList.get(i) != null && tradeList.get(i).getFocusedList(focus).size() > 0) {
                 levels.add(i);
+            }
+        }
         return levels;
     }
 

--- a/Common/src/main/java/jeresources/entry/AbstractVillagerEntry.java
+++ b/Common/src/main/java/jeresources/entry/AbstractVillagerEntry.java
@@ -1,0 +1,85 @@
+package jeresources.entry;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import jeresources.collection.TradeList;
+import mezz.jei.api.recipe.IFocus;
+import net.minecraft.world.entity.npc.AbstractVillager;
+import net.minecraft.world.entity.npc.VillagerTrades;
+import net.minecraft.world.item.ItemStack;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class AbstractVillagerEntry<T extends AbstractVillager> {
+    private final List<TradeList> tradeList;
+    @Nullable
+    protected T entity;
+
+    public AbstractVillagerEntry(Int2ObjectMap<VillagerTrades.ItemListing[]> itemListings) {
+        this.tradeList = new LinkedList<>();
+        addITradeLists(itemListings);
+    }
+
+    public void addITradeLists(Int2ObjectMap<VillagerTrades.ItemListing[]> itemListings) {
+        for (int i = 1;i < itemListings.size() + 1;i++) {
+            VillagerTrades.ItemListing[] levelList = itemListings.get(i);
+            TradeList trades = this.tradeList.size() > i ? this.tradeList.get(i) : new TradeList(entity);
+            trades.addITradeList(levelList);
+            this.tradeList.add(trades);
+        }
+    }
+
+    public TradeList getVillagerTrades(int level) {
+        if (tradeList.size() > level) {
+            return tradeList.get(level);
+        } else {
+            return new TradeList(null);
+        }
+    }
+
+    public List<ItemStack> getInputs() {
+        List<ItemStack> list = new LinkedList<>();
+        for (List<TradeList.Trade> trades : this.tradeList) {
+            for (TradeList.Trade trade : trades) {
+                list.add(trade.getMinCostA());
+                if (!trade.getMinCostB().isEmpty())
+                    list.add(trade.getMinCostB());
+            }
+        }
+        return list;
+    }
+
+    public List<ItemStack> getOutputs() {
+        List<ItemStack> list = new LinkedList<>();
+        for (List<TradeList.Trade> trades : this.tradeList)
+            list.addAll(trades.stream().map(TradeList.Trade::getMinResult).collect(Collectors.toList()));
+        return list;
+    }
+
+    public int getMaxLevel() {
+        return tradeList.size();
+    }
+
+    public abstract String getName();
+
+    public abstract String getDisplayName();
+
+    public List<Integer> getPossibleLevels(IFocus<ItemStack> focus) {
+        List<Integer> levels = new ArrayList<>();
+        for (int i = 0; i < tradeList.size(); i++)
+            if (tradeList.get(i) != null && tradeList.get(i).getFocusedList(focus).size() > 0)
+                levels.add(i);
+        return levels;
+    }
+
+    public abstract T getVillagerEntity();
+
+    public abstract List<ItemStack> getPois();
+
+    public abstract boolean hasPois();
+
+    public abstract boolean hasLevels();
+}

--- a/Common/src/main/java/jeresources/entry/VillagerEntry.java
+++ b/Common/src/main/java/jeresources/entry/VillagerEntry.java
@@ -1,78 +1,31 @@
 package jeresources.entry;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import jeresources.collection.TradeList;
 import jeresources.compatibility.CompatBase;
 import jeresources.util.VillagersHelper;
-import mezz.jei.api.recipe.IFocus;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class VillagerEntry {
-    private final List<TradeList> tradeList;
+public class VillagerEntry extends AbstractVillagerEntry<Villager>{
     private final VillagerProfession profession;
-    @Nullable
-    private Villager entity;
 
     public VillagerEntry(VillagerProfession profession, Int2ObjectMap<VillagerTrades.ItemListing[]> itemListings) {
+        super(itemListings);
         this.profession = profession;
-        this.tradeList = new LinkedList<>();
-        addITradeLists(itemListings);
     }
 
-    public void addITradeLists(Int2ObjectMap<VillagerTrades.ItemListing[]> itemListings) {
-        for (int i = 1;i < itemListings.size() + 1;i++) {
-            VillagerTrades.ItemListing[] levelList = itemListings.get(i);
-            TradeList trades = this.tradeList.size() > i ? this.tradeList.get(i) : new TradeList(this);
-            trades.addITradeList(levelList);
-            this.tradeList.add(trades);
-        }
-    }
-
-    public TradeList getVillagerTrades(int level) {
-        if (tradeList.size() > level) {
-            return tradeList.get(level);
-        } else {
-            return new TradeList(null);
-        }
-    }
-
-    public List<ItemStack> getInputs() {
-        List<ItemStack> list = new LinkedList<>();
-        for (List<TradeList.Trade> trades : this.tradeList) {
-            for (TradeList.Trade trade : trades) {
-                list.add(trade.getMinCostA());
-                if (!trade.getMinCostB().isEmpty())
-                    list.add(trade.getMinCostB());
-            }
-        }
-        return list;
-    }
-
-    public List<ItemStack> getOutputs() {
-        List<ItemStack> list = new LinkedList<>();
-        for (List<TradeList.Trade> trades : this.tradeList)
-            list.addAll(trades.stream().map(TradeList.Trade::getMinResult).collect(Collectors.toList()));
-        return list;
-    }
-
-    public int getMaxLevel() {
-        return tradeList.size();
-    }
-
+    @Override
     public String getName() {
         return this.profession.toString();
     }
 
+    @Override
     public String getDisplayName() {
         return "entity.minecraft.villager." + this.profession.toString();
     }
@@ -81,14 +34,7 @@ public class VillagerEntry {
         return this.profession;
     }
 
-    public List<Integer> getPossibleLevels(IFocus<ItemStack> focus) {
-        List<Integer> levels = new ArrayList<>();
-        for (int i = 0; i < tradeList.size(); i++)
-            if (tradeList.get(i) != null && tradeList.get(i).getFocusedList(focus).size() > 0)
-                levels.add(i);
-        return levels;
-    }
-
+    @Override
     public Villager getVillagerEntity() {
         if (this.entity == null) {
             /*
@@ -103,11 +49,18 @@ public class VillagerEntry {
         return this.entity;
     }
 
+    @Override
     public List<ItemStack> getPois() {
         return VillagersHelper.getPoiBlocks(this.profession.heldJobSite()).stream().map(blockstate -> new ItemStack(blockstate.getBlock())).collect(Collectors.toList());
     }
 
+    @Override
     public boolean hasPois() {
         return !VillagersHelper.getPoiBlocks(this.profession.heldJobSite()).isEmpty();
+    }
+
+    @Override
+    public boolean hasLevels() {
+        return true;
     }
 }

--- a/Common/src/main/java/jeresources/entry/WanderingTraderEntry.java
+++ b/Common/src/main/java/jeresources/entry/WanderingTraderEntry.java
@@ -1,0 +1,56 @@
+package jeresources.entry;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import jeresources.compatibility.CompatBase;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.npc.VillagerTrades;
+import net.minecraft.world.entity.npc.WanderingTrader;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Collections;
+import java.util.List;
+
+public class WanderingTraderEntry extends AbstractVillagerEntry<WanderingTrader> {
+
+    public WanderingTraderEntry(Int2ObjectMap<VillagerTrades.ItemListing[]> itemListings) {
+        super(itemListings);
+    }
+
+    @Override
+    public String getName() {
+        return "wandering_trader";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "entity.minecraft.wandering_trader";
+    }
+
+    public WanderingTrader getVillagerEntity() {
+        if (this.entity == null) {
+            /*
+             * level must be a client level here.
+             * Passing in a ServerLevel can allow villagers to load all kinds of things,
+             * like in the `VillagerTrades.TreasureMapForEmeralds` which loads chunks!
+             */
+            this.entity = EntityType.WANDERING_TRADER.create(CompatBase.getLevel());
+            assert this.entity != null;
+        }
+        return this.entity;
+    }
+
+    @Override
+    public List<ItemStack> getPois() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean hasPois() {
+        return false;
+    }
+
+    @Override
+    public boolean hasLevels() {
+        return false;
+    }
+}

--- a/Common/src/main/java/jeresources/jei/villager/VillagerWrapper.java
+++ b/Common/src/main/java/jeresources/jei/villager/VillagerWrapper.java
@@ -2,24 +2,24 @@ package jeresources.jei.villager;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import jeresources.collection.TradeList;
-import jeresources.entry.VillagerEntry;
+import jeresources.entry.AbstractVillagerEntry;
 import jeresources.reference.Resources;
 import jeresources.util.Font;
 import jeresources.util.RenderHelper;
 import jeresources.util.TranslationHelper;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.category.extensions.IRecipeCategoryExtension;
-import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.entity.npc.AbstractVillager;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 public class VillagerWrapper implements IRecipeCategoryExtension {
-    private final VillagerEntry entry;
+    private final AbstractVillagerEntry<?> entry;
     private IFocus<ItemStack> focus;
 
-    public VillagerWrapper(VillagerEntry entry) {
+    public VillagerWrapper(AbstractVillagerEntry<?> entry) {
         this.entry = entry;
     }
 
@@ -47,10 +47,14 @@ public class VillagerWrapper implements IRecipeCategoryExtension {
         return entry.hasPois();
     }
 
+    public boolean hasLevels() {
+        return entry.hasLevels();
+    }
+
     @Override
     public void drawInfo(int recipeWidth, int recipeHeight, @NotNull PoseStack poseStack, double mouseX, double mouseY) {
         RenderHelper.scissor(poseStack,7, 43, 59, 79);
-        Villager villager = entry.getVillagerEntity();
+        AbstractVillager villager = entry.getVillagerEntity();
         RenderHelper.renderEntity(
             poseStack,
             37, 118, 36.0F,
@@ -68,9 +72,11 @@ public class VillagerWrapper implements IRecipeCategoryExtension {
             RenderHelper.drawTexture(poseStack, VillagerCategory.X_FIRST_ITEM + VillagerCategory.X_ITEM_DISTANCE, y + i * VillagerCategory.Y_ITEM_DISTANCE, 22, 120, 18, 18, Resources.Gui.Jei.VILLAGER.getResource());
             RenderHelper.drawTexture(poseStack, VillagerCategory.X_ITEM_RESULT, y + i * VillagerCategory.Y_ITEM_DISTANCE, 22, 120, 18, 18, Resources.Gui.Jei.VILLAGER.getResource());
         }
-        i = 0;
-        for (int level : getPossibleLevels(focus)) {
-            Font.normal.print(poseStack, "lv. " + (level + 1), 72, y + i++ * VillagerCategory.Y_ITEM_DISTANCE + 6);
+        if (entry.hasLevels()) {
+            i = 0;
+            for (int level : getPossibleLevels(focus)) {
+                Font.normal.print(poseStack, "lv. " + (level + 1), 72, y + i++ * VillagerCategory.Y_ITEM_DISTANCE + 6);
+            }
         }
 
         Font.normal.print(poseStack, TranslationHelper.translateAndFormat(entry.getDisplayName()), 5, 5);

--- a/Common/src/main/java/jeresources/registry/VillagerRegistry.java
+++ b/Common/src/main/java/jeresources/registry/VillagerRegistry.java
@@ -1,6 +1,6 @@
 package jeresources.registry;
 
-import jeresources.entry.VillagerEntry;
+import jeresources.entry.AbstractVillagerEntry;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -8,7 +8,7 @@ import java.util.List;
 public class VillagerRegistry {
     private static VillagerRegistry instance;
 
-    private List<VillagerEntry> villagers;
+    private List<AbstractVillagerEntry<?>> villagers;
 
     public static VillagerRegistry getInstance() {
         if (instance == null) {
@@ -21,13 +21,13 @@ public class VillagerRegistry {
         this.villagers = new LinkedList<>();
     }
 
-    public void addVillagerEntry(VillagerEntry entry) {
+    public void addVillagerEntry(AbstractVillagerEntry<?> entry) {
         if (entry.getVillagerTrades(0).size() > 0) {
             this.villagers.add(entry);
         }
     }
 
-    public List<VillagerEntry> getVillagers() {
+    public List<AbstractVillagerEntry<?>> getVillagers() {
         return this.villagers;
     }
 

--- a/Common/src/main/java/jeresources/util/VillagersHelper.java
+++ b/Common/src/main/java/jeresources/util/VillagersHelper.java
@@ -2,7 +2,9 @@ package jeresources.util;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import jeresources.entry.VillagerEntry;
+import jeresources.entry.WanderingTraderEntry;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.world.entity.ai.village.poi.PoiType;
@@ -10,6 +12,7 @@ import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.level.block.state.BlockState;
 
+import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -23,10 +26,26 @@ public class VillagersHelper {
                 LogHelper.warn("Exception caught when registering villager", e);
             }
         }
+        try {
+            reg.addVillagerEntry(new WanderingTraderEntry(getWanderingTrades()));
+        } catch (Exception e) {
+            LogHelper.warn("Failed loading wandering trader");
+            LogHelper.warn("Exception caught when registering wandering traderr", e);
+        }
     }
 
     private static Int2ObjectMap<VillagerTrades.ItemListing[]> getTrades(VillagerProfession profession) {
         return VillagerTrades.TRADES.getOrDefault(profession, Int2ObjectMaps.emptyMap());
+    }
+
+    private static Int2ObjectMap<VillagerTrades.ItemListing[]> getWanderingTrades() {
+        // Wandering trader doesn't have levels, but has a separate array for special items
+        // This combines all wandering trader lists, so it can be treated as a villager with 1 level
+        VillagerTrades.ItemListing[] allWanderingTrades = VillagerTrades.WANDERING_TRADER_TRADES.values()
+            .stream()
+            .flatMap(x -> Arrays.stream(x))
+            .toArray(VillagerTrades.ItemListing[]::new);
+        return new Int2ObjectOpenHashMap<>(new int[]{1}, new VillagerTrades.ItemListing[][]{allWanderingTrades});
     }
 
     public static Set<BlockState> getPoiBlocks(PoiType poiType) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,4 +41,4 @@ curseProjectId=240630
 curseHomepageLink=https://www.curseforge.com/minecraft/mc-mods/just-enough-resources-jer
 
 # Version
-specificationVersion=1.1.1
+specificationVersion=1.2.0


### PR DESCRIPTION
This PR adds Wandering Trader trades to the existing villager trades tab. Should handle https://github.com/way2muchnoise/JustEnoughResources/issues/259

This ended up being a larger refactor than I had anticipated, so let me know if you have any questions or want anything changed. A quick overview of big changes is that I created a new `WanderingTraderEntry` class and a new `AbstractVillagerEntry` class. I also changed the existing `VillagerEntry` class to extend `AbstractVillagerEntry` in order to avoid duplication.

Here's a screenshot of how this looks in game.

![image](https://user-images.githubusercontent.com/10429583/198493281-ad37e689-9852-4198-a4f9-0fd469cada39.png)