### PR TITLE
Set focus on VillagerWrapper

### DIFF
--- a/Common/src/main/java/jeresources/jei/villager/VillagerCategory.java
+++ b/Common/src/main/java/jeresources/jei/villager/VillagerCategory.java
@@ -50,6 +50,7 @@ public class VillagerCategory extends BlankJEIRecipeCategory<VillagerWrapper> {
         }
 
         IFocus<ItemStack> focus = focuses.getFocuses(VanillaTypes.ITEM_STACK).findFirst().orElse(null);
+        recipeWrapper.setFocus(focus);
         List<Integer> possibleLevels = recipeWrapper.getPossibleLevels(focus);
         int y = 1 + Y_ITEM_DISTANCE * (6 - possibleLevels.size()) / 2;
         for (int i = 0; i < possibleLevels.size(); i++) {


### PR DESCRIPTION
Noticed this weirdness in the UI while I was working on the wandering trader PR and the fix seems pretty simple. The VillagerWrapper focus was always null causing all levels to be rendered no matter which were relevant to the displayed recipe. This sets it to fix the issue.

Before Fix:
![levelbroken](https://user-images.githubusercontent.com/10429583/198754726-e16d22ed-1aef-4d59-bf16-bb74b2f7ec25.png)
![levelbroken2](https://user-images.githubusercontent.com/10429583/198754728-08afaf5a-7832-4991-bbe6-9124e3b1b5b4.png)

After Fix:
![betterlevelfix2](https://user-images.githubusercontent.com/10429583/198754762-facd124f-d24c-424a-9793-c89b9594703f.png)
![betterLevelFix](https://user-images.githubusercontent.com/10429583/198754766-11cfa7dc-d3f1-48e5-9b6f-b0498082a65f.png)
