### PR TITLE
1.19.3 branch

### DIFF
--- a/Common/src/main/java/jeresources/jei/mob/MobCategory.java
+++ b/Common/src/main/java/jeresources/jei/mob/MobCategory.java
@@ -61,7 +61,7 @@ public class MobCategory extends BlankJEIRecipeCategory<MobWrapper> {
             xOffset += 72 / Settings.ITEMS_PER_ROW;
         }
         if (recipeWrapper.hasSpawnEgg()) {
-            builder.addSlot(RecipeIngredientRole.CATALYST, 151, 19).addItemStack(recipeWrapper.getSpawnEgg());
+            builder.addSlot(RecipeIngredientRole.CATALYST, 151, 22).addItemStack(recipeWrapper.getSpawnEgg());
         }
     }
 }

--- a/Common/src/main/resources/assets/jeresources/lang/en_us.json
+++ b/Common/src/main/resources/assets/jeresources/lang/en_us.json
@@ -99,7 +99,7 @@
 	"jer.mob.title": "Mob Drops",
 	"jer.mob.spawn": "Spawn Biome:",
 	"jer.mob.biome": "Spawn Biomes: Hover mouse here",
-	"jer.mob.exp": "Experience Dropped",
+	"jer.mob.exp": "Experience",
 
 	"_comment": "#Villager View",
 	"jer.villager.title": "Villager Trades",

--- a/Common/src/main/resources/assets/jeresources/lang/es_es.json
+++ b/Common/src/main/resources/assets/jeresources/lang/es_es.json
@@ -99,7 +99,7 @@
 	"jer.mob.title": "Obtención de criatura",
 	"jer.mob.spawn": "Bioma de generación:",
 	"jer.mob.biome": "Biomas de generación: Coloca el mouse aquí",
-	"jer.mob.exp": "Experiencia soltada",
+	"jer.mob.exp": "Experiencia",
 
 	"_comment": "#Villager View",
 	"jer.villager.title": "Comercios de aldeanos",

--- a/Common/src/main/resources/assets/jeresources/lang/fr_fr.json
+++ b/Common/src/main/resources/assets/jeresources/lang/fr_fr.json
@@ -99,7 +99,7 @@
 	"jer.mob.title": "Butin de créatures",
 	"jer.mob.spawn": "Biome d'apparition :",
 	"jer.mob.biome": "Spawn Biomes : Passez la souris ici",
-	"jer.mob.exp": "Expérience lachée",
+	"jer.mob.exp": "Expérience",
 
 	"_comment": "#Villager View",
 	"jer.villager.title": "Echanges villageois",

--- a/Common/src/main/resources/assets/jeresources/lang/it_it.json
+++ b/Common/src/main/resources/assets/jeresources/lang/it_it.json
@@ -99,7 +99,7 @@
 	"jer.mob.title": "Rilascio delle creature",
 	"jer.mob.spawn": "Bioma di Generazione:",
 	"jer.mob.biome": "Biomi di generazione: mantieni il mouse qui",
-	"jer.mob.exp": "Esperienza ottenuta",
+	"jer.mob.exp": "Esperienza",
 
 	"_comment": "#Villager View",
 	"jer.villager.title": "Commercio con i Villici",

--- a/Common/src/main/resources/assets/jeresources/lang/ko_kr.json
+++ b/Common/src/main/resources/assets/jeresources/lang/ko_kr.json
@@ -99,7 +99,7 @@
 	"jer.mob.title": "몹 드롭",
 	"jer.mob.spawn": "생성 생물군계:",
 	"jer.mob.biome": "생성 생물군계: 여기에 마우스",
-	"jer.mob.exp": "경험치 드롭량",
+	"jer.mob.exp": "경험치",
 
 	"_comment": "#Villager View",
 	"jer.villager.title": "주민 거래",

--- a/Common/src/main/resources/assets/jeresources/lang/nl_nl.json
+++ b/Common/src/main/resources/assets/jeresources/lang/nl_nl.json
@@ -41,7 +41,7 @@
 	"_comment": "#Mob View",
 	"jer.mob.title": "Mob Drops",
 	"jer.mob.biome": "Spawn Biomes: Hover muis hier",
-	"jer.mob.exp": "Experience Dropped",
+	"jer.mob.exp": "Experience",
 
 	"_comment": "#Conditionals - when translating retain '%s' as this lets the modifier be properly inserted into the string",
 	"jer.magmaCream.text": "Grote en kleine Magma Cubes",

--- a/Common/src/main/resources/assets/jeresources/lang/pt_br.json
+++ b/Common/src/main/resources/assets/jeresources/lang/pt_br.json
@@ -99,7 +99,7 @@
 	"jer.mob.title": "Mob Drops",
 	"jer.mob.spawn": "Spawn Bioma:",
 	"jer.mob.biome": "Spawn Biomas: Passe o mouse aqui",
-	"jer.mob.exp": "Experiência dropada",
+	"jer.mob.exp": "Experiência",
 
 	"_comment": "#Villager View",
 	"jer.villager.title": "Comércio com aldeões",

--- a/Common/src/main/resources/assets/jeresources/lang/ru_ru.json
+++ b/Common/src/main/resources/assets/jeresources/lang/ru_ru.json
@@ -97,7 +97,7 @@
     "jer.mob.title": "Выпадение из мобов",
     "jer.mob.spawn": "Появляется в биоме:",
     "jer.mob.biome": "Появляется в биомах: наведите курсор сюда",
-    "jer.mob.exp": "Даёт опыта",
+    "jer.mob.exp": "опыта",
 
     "_comment": "#Villager View",
     "jer.villager.title": "Торговля с жителем",

--- a/Common/src/main/resources/assets/jeresources/lang/zh_cn.json
+++ b/Common/src/main/resources/assets/jeresources/lang/zh_cn.json
@@ -101,7 +101,7 @@
 	"jer.mob.title": "生物资源",
 	"jer.mob.spawn": "生成群系：",
 	"jer.mob.biome": "生成群系：将鼠标悬停在此处查看",
-	"jer.mob.exp": "掉落经验",
+	"jer.mob.exp": "经验",
 
 	"_comment": "#Villager View",
 	"jer.villager.title": "村民交易",

--- a/Common/src/main/resources/assets/jeresources/lang/zh_tw.json
+++ b/Common/src/main/resources/assets/jeresources/lang/zh_tw.json
@@ -97,7 +97,7 @@
 	"jer.mob.title": "生物戰利品",
 	"jer.mob.spawn": "生成生態域：",
 	"jer.mob.biome": "生成生態域：將游標停留在此處以查看",
-	"jer.mob.exp": "掉落經驗",
+	"jer.mob.exp": "經驗",
 
 	"_comment": "#Villager View",
 	"jer.villager.title": "村民交易",

--- a/Common/src/main/resources/pack.mcmeta
+++ b/Common/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
    "pack":{
-      "pack_format":9,
+      "pack_format":10,
       "description":"JER Resources"
    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,4 +41,4 @@ curseProjectId=240630
 curseHomepageLink=https://www.curseforge.com/minecraft/mc-mods/just-enough-resources-jer
 
 # Version
-specificationVersion=1.3.1
+specificationVersion=1.3.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ forgeVersionRange=[44.0.0,)
 fabricVersion=0.73.0+1.19.3
 fabricLoaderVersion=0.14.13
 
-#JEI
+# JEI
 jeiVersion=12.1.1.8
 
 # Fabric Config screen


### PR DESCRIPTION
Added spawn egg slot to 1.19.3
Changed "Experience Dropped" to "Experience". Ender dragon exp was overlapping with spawn egg slot.
Updated pack_format to match 1.19.3
Updated specificationVersion to 1.3.2