### PR TITLE
fix 'Wrong filesystem' error by translating PathPath's into their underlying UnionPaths

### DIFF
--- a/Forge/src/main/java/jeresources/forge/ModInfo.java
+++ b/Forge/src/main/java/jeresources/forge/ModInfo.java
@@ -22,6 +22,18 @@ public class ModInfo implements IModInfo {
 
     @Override
     public List<? extends PackResources> getPackResources() {
-        return List.of(new PathPackResources(modFile.getFile().getFileName(), false, modFile.getFile().getFilePath()));
+        Path source = modFile.getFile().getFilePath();
+        // for nested jars, the file path is actually a PathPath, it's fileSystem is a
+        // PathFileSystem, but the source.fileSystem.target is a UnionPath pointing to
+        // a UnionFileSystem which is what forge uses, which is what we want, so that
+        // it matches internal registers, without this we'll get 'Wrong filesystem'
+        // errors even though they're the same file pointing to the same thing
+        //
+        // tldr: if it's a PathFileSystem, make it a UnionFileSystem
+        if (PathPath.class.isAssignableFrom(source.getClass())) {
+            PathFileSystem pfs = ((PathPath)source).getFileSystem();
+            source = pfs.getTarget();
+        }
+        return List.of(new PathPackResources(modFile.getFile().getFileName(), source));
     }
 }


### PR DESCRIPTION
In all honesty I'm not sure why this occurs, this is running on All The Mods 8 with stock standard pack configuration.

**What:**
[See logs here.](https://github.com/way2muchnoise/JustEnoughResources/files/12043454/jer.log)

Essentially `LootTableHelper.java:205` will always crash when calling `reloadableResourceManager.createReload(...)` because the `packs` passed to it have `source` paths as `PathPath` whereas the ModList they're checked against will always be `UnionPath`.

![idea64_ixrqS3tm8f](https://github.com/way2muchnoise/JustEnoughResources/assets/26195151/e15fee72-236c-443e-9571-e43129af252d)

**How do we solve this?**
This change checks when `modFile.getFile().getFilePath()` is of type `PathPath`. If it is, it will use `PathPath.getFileSystem().getTarget()` as the new source. This was discovered as a solution by debugging and inspecting what happens.

Example of a normal jar
![idea64_DdMgv6NCGk](https://github.com/way2muchnoise/JustEnoughResources/assets/26195151/567b00e2-ffa1-4cc8-a0a7-9235a7ab241f)

Example of a nested jar
![image](https://github.com/way2muchnoise/JustEnoughResources/assets/26195151/33a94306-6e78-4daa-9832-28eccfae3156)