### PR TITLE
[1.19.2] Fix for IndexOutOfBoundsException when loading world-gen.json

### DIFF
--- a/CommonApi/src/main/java/jeresources/api/distributions/DistributionHelpers.java
+++ b/CommonApi/src/main/java/jeresources/api/distributions/DistributionHelpers.java
@@ -235,7 +235,7 @@ public class DistributionHelpers {
         Set<OrePoint> set = new TreeSet<>();
         Collections.addAll(set, points);
         points = set.toArray(new OrePoint[set.size()]);
-        float[] array = new float[256 + 64];
+        float[] array = new float[320 + 64];
         addDistribution(array, getRampDistribution(0, points[0].level, points[0].chance));
         for (int i = 1; i < points.length; i++) {
             OrePoint min, max;


### PR DESCRIPTION
Hello,

While utilizing the JustEnoughResources (JER) mod and generating the `world-gen.json` file via the [RegionScanner](https://github.com/RundownRhino/RegionScanner) tool for a Minecraft 1.19.2 environment, I encountered an `IndexOutOfBoundsException`. The issue seems to originate from [this line of code](https://github.com/way2muchnoise/JustEnoughResources/blob/6936b3a5abf850b8b9b189c301cf99e0552dd10e/CommonApi/src/main/java/jeresources/api/distributions/DistributionHelpers.java#L252).

I'd like to highlight that the issue was particularly triggered when generating the `world-gen.json` file for the "Advanced Mining Dimension" mod. This mod utilizes the full world height. Given this usage, it brought the `IndexOutOfBoundsException` to the forefront.

I suspect that the error arises due to the updated world height in Minecraft 1.18, which now spans from `-64` to `320`.

### Proposed Changes:
1. To address this, I adjusted the size of the distribution array from `320` to `384`, ensuring it can handle the full y-value range of Minecraft 1.18+.

With these modifications, the exception no longer appears, and JER's `getDistributionFromPoints` function produces what seem to be accurate distributions, particularly when processing data from the `world-gen.json` generated by RegionScanner.

**Note**: Although this solution has resolved the issue in my setup, I would appreciate feedback and validation from the JER community to confirm its overall effectiveness.

Thank you for your time and consideration. I eagerly await any insights or suggestions related to this change.

Thanks for this awesome mod :)

Best regards,
F0x06