### PR TITLE
Fixed getLootTables() with some mods like Thermal Foundation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,4 +41,4 @@ curseProjectId=240630
 curseHomepageLink=https://www.curseforge.com/minecraft/mc-mods/just-enough-resources-jer
 
 # Version
-specificationVersion=1.2.2
+specificationVersion=1.2.3


### PR DESCRIPTION
Hi,

When i added Thermal suite mods to my modpack i encountered the following error:

```
[22:04:25] [Render thread/ERROR]: Caught an error from mod plugin: class jeresources.jei.JEIConfig minecraft:jeresources
java.lang.IllegalArgumentException: Wrong filesystem
	at cpw.mods.niofs.union.UnionPath.relativize(UnionPath.java:227) ~[securejarhandler-2.1.4.jar:?]
	at net.minecraftforge.jarjar.nio.pathfs.PathFileSystem.lambda$newDirectoryStream$4(PathFileSystem.java:210) ~[JarJarFileSystems-0.3.16.jar:?]
	at net.minecraftforge.jarjar.nio.pathfs.PathFSUtils$2$1.next(PathFSUtils.java:63) ~[JarJarFileSystems-0.3.16.jar:?]
	at net.minecraftforge.jarjar.nio.pathfs.PathFSUtils$2$1.next(PathFSUtils.java:52) ~[JarJarFileSystems-0.3.16.jar:?]
	at java.nio.file.FileTreeWalker.next(FileTreeWalker.java:350) ~[?:?]
	at java.nio.file.FileTreeIterator.fetchNextIfNeeded(FileTreeIterator.java:83) ~[?:?]
	at java.nio.file.FileTreeIterator.hasNext(FileTreeIterator.java:103) ~[?:?]
	at java.util.Iterator.forEachRemaining(Iterator.java:132) ~[?:?]
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at net.minecraftforge.resource.PathPackResources.getNamespacesFromDisk(PathPackResources.java:174) ~[forge-1.19.2-43.3.0-universal.jar%23700!/:?]
	at net.minecraftforge.resource.PathPackResources.init(PathPackResources.java:68) ~[forge-1.19.2-43.3.0-universal.jar%23700!/:?]
	at net.minecraft.server.packs.resources.MultiPackResourceManager.lambda$new$0(MultiPackResourceManager.java:27) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
	at net.minecraft.server.packs.resources.MultiPackResourceManager.<init>(MultiPackResourceManager.java:27) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.server.packs.resources.ReloadableResourceManager.m_142463_(ReloadableResourceManager.java:44) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at jeresources.util.LootTableHelper.getLootTables(LootTableHelper.java:183) ~[JustEnoughResources-1.19.2-1.2.2.local.jar%23558!/:1.2.2.local]
	at jeresources.util.LootTableHelper.toDrops(LootTableHelper.java:96) ~[JustEnoughResources-1.19.2-1.2.2.local.jar%23558!/:1.2.2.local]
	at jeresources.util.PlantHelper.getSeeds(PlantHelper.java:14) ~[JustEnoughResources-1.19.2-1.2.2.local.jar%23558!/:1.2.2.local]
	at jeresources.entry.PlantEntry.registerGrass(PlantEntry.java:28) ~[JustEnoughResources-1.19.2-1.2.2.local.jar%23558!/:1.2.2.local]
	at jeresources.registry.PlantRegistry.<init>(PlantRegistry.java:25) ~[JustEnoughResources-1.19.2-1.2.2.local.jar%23558!/:1.2.2.local]
	at jeresources.registry.PlantRegistry.getInstance(PlantRegistry.java:19) ~[JustEnoughResources-1.19.2-1.2.2.local.jar%23558!/:1.2.2.local]
	at jeresources.proxy.CommonProxy.initCompatibility(CommonProxy.java:11) ~[JustEnoughResources-1.19.2-1.2.2.local.jar%23558!/:1.2.2.local]
	at jeresources.jei.JEIConfig.registerCategories(JEIConfig.java:98) ~[JustEnoughResources-1.19.2-1.2.2.local.jar%23558!/:1.2.2.local]
	at mezz.jei.library.load.PluginLoader.lambda$createRecipeCategories$3(PluginLoader.java:88) ~[jei-1.19.2-forge-11.6.0.1018.jar%23556!/:11.6.0.1018]
	at mezz.jei.library.load.PluginCaller.callOnPlugins(PluginCaller.java:25) ~[jei-1.19.2-forge-11.6.0.1018.jar%23556!/:11.6.0.1018]
	at mezz.jei.library.load.PluginLoader.createRecipeCategories(PluginLoader.java:88) ~[jei-1.19.2-forge-11.6.0.1018.jar%23556!/:11.6.0.1018]
	at mezz.jei.library.load.PluginLoader.createRecipeManager(PluginLoader.java:117) ~[jei-1.19.2-forge-11.6.0.1018.jar%23556!/:11.6.0.1018]
	at mezz.jei.library.startup.JeiStarter.start(JeiStarter.java:114) ~[jei-1.19.2-forge-11.6.0.1018.jar%23556!/:11.6.0.1018]
	at mezz.jei.forge.startup.StartEventObserver.transitionState(StartEventObserver.java:137) ~[jei-1.19.2-forge-11.6.0.1018.jar%23556!/:11.6.0.1018]
	at mezz.jei.forge.startup.StartEventObserver.onEvent(StartEventObserver.java:100) ~[jei-1.19.2-forge-11.6.0.1018.jar%23556!/:11.6.0.1018]
	at net.minecraftforge.eventbus.EventBus.doCastFilter(EventBus.java:260) ~[eventbus-6.0.3.jar%2385!/:?]
	at net.minecraftforge.eventbus.EventBus.lambda$addListener$11(EventBus.java:252) ~[eventbus-6.0.3.jar%2385!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:315) ~[eventbus-6.0.3.jar%2385!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:296) ~[eventbus-6.0.3.jar%2385!/:?]
	at net.minecraft.client.multiplayer.ClientPacketListener.m_5859_(ClientPacketListener.java:1321) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket.m_5797_(ClientboundUpdateTagsPacket.java:35) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket.m_5797_(ClientboundUpdateTagsPacket.java:11) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.network.protocol.PacketUtils.m_131356_(PacketUtils.java:22) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_6367_(BlockableEventLoop.java:157) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.m_6367_(ReentrantBlockableEventLoop.java:23) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_7245_(BlockableEventLoop.java:131) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.util.thread.BlockableEventLoop.m_18699_(BlockableEventLoop.java:116) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.client.Minecraft.m_91383_(Minecraft.java:1072) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.client.Minecraft.m_91374_(Minecraft.java:700) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.client.main.Main.m_239872_(Main.java:212) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at net.minecraft.client.main.Main.main(Main.java:51) ~[client-1.19.2-20220805.130853-srg.jar%23695!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at net.minecraftforge.fml.loading.targets.CommonClientLaunchHandler.lambda$launchService$0(CommonClientLaunchHandler.java:27) ~[fmlloader-1.19.2-43.3.0.jar%23101!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30) [modlauncher-10.0.8.jar%2388!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-10.0.8.jar%2388!/:?]
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-10.0.8.jar%2388!/:?]
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:106) [modlauncher-10.0.8.jar%2388!/:?]
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:77) [modlauncher-10.0.8.jar%2388!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-10.0.8.jar%2388!/:?]
	at cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-10.0.8.jar%2388!/:?]
	at cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:141) [bootstraplauncher-1.1.2.jar:?]
```

Apparently it was caused by the loading of the thermal_core.jar inside thermal-foundation.jar (jarjar), i managed to solve the issue by using `Minecraft.getInstance().getResourcePackRepository().getSelectedPacks().stream().map(Pack::open).toList()` to get all the resource packs instead of `Services.PLATFORM.getModsList().getMods().forEach(mod ->...` this will prevent unwanted mods to be added to the `packs` List.

Hope this helps,

Regards,
F0x06.

# How to test/reproduce

Add the folllowing dependencies to `Forge/build.gradle.kts`
```kotlin
runtimeOnly(fg.deobf("maven.modrinth:cofh-core:10.3.0"))
runtimeOnly(fg.deobf("maven.modrinth:thermal-foundation:10.3.0"))
runtimeOnly(fg.deobf("maven.modrinth:thermal-cultivation:10.3.0"))
runtimeOnly(fg.deobf("maven.modrinth:thermal-dynamics:10.3.0"))
runtimeOnly(fg.deobf("maven.modrinth:thermal-expansion:10.3.0"))
runtimeOnly(fg.deobf("maven.modrinth:thermal-innovation:10.3.0"))
runtimeOnly(fg.deobf("maven.modrinth:thermal-integration:10.3.0"))
runtimeOnly(fg.deobf("maven.modrinth:thermal-locomotion:10.3.0"))
```

Also add the modrinth maven repository:
```kotlin
maven("https://api.modrinth.com/maven")
```

Start the `Forge->forgegradle runs->Server`
Start the `Forge->forgegradle runs->runClientDev` and connect to the server