### PR TITLE
Discover forge plugins

### DIFF
--- a/Forge/src/main/java/jeresources/forge/ForgePlatformHelper.java
+++ b/Forge/src/main/java/jeresources/forge/ForgePlatformHelper.java
@@ -3,6 +3,7 @@ package jeresources.forge;
 import jeresources.JEResources;
 import jeresources.api.IJERAPI;
 import jeresources.api.IJERPlugin;
+import jeresources.api.JERPlugin;
 import jeresources.platform.ILootTableHelper;
 import jeresources.platform.IModList;
 import jeresources.platform.IPlatformHelper;
@@ -49,7 +50,7 @@ public class ForgePlatformHelper implements IPlatformHelper {
 
     @Override
     public void injectApi(IJERAPI instance) {
-        Type pluginAnnotation = Type.getType(IJERPlugin.class);
+        Type pluginAnnotation = Type.getType(JERPlugin.class);
         List<ModFileScanData> allScanData = ModList.get().getAllScanData();
         for (ModFileScanData scanData : allScanData) {
             Iterable<ModFileScanData.AnnotationData> annotations = scanData.getAnnotations();


### PR DESCRIPTION
Currently, JER uses the plugin base interface as annotation type, it scans for. This pull request fixes that, so JER correctly scans for the annotation and therefore allows plugins to load on forge.