### PR TITLE
fix: adds cleanup logic when unloading level to avoid memory leak

### DIFF
--- a/Common/src/main/java/jeresources/collection/TradeList.java
+++ b/Common/src/main/java/jeresources/collection/TradeList.java
@@ -1,5 +1,7 @@
 package jeresources.collection;
 
+import jeresources.entry.AbstractVillagerEntry;
+import jeresources.entry.VillagerEntry;
 import mezz.jei.api.recipe.IFocus;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.npc.AbstractVillager;
@@ -16,10 +18,10 @@ import java.util.stream.Collectors;
 public class TradeList extends LinkedList<TradeList.Trade> {
     private static final Random r = new Random();
 
-    private AbstractVillager entity;
+    private final AbstractVillagerEntry<?> entry;
 
-    public TradeList(AbstractVillager entity) {
-        this.entity = entity;
+    public TradeList(AbstractVillagerEntry<?> entry) {
+        this.entry = entry;
     }
 
     public List<ItemStack> getCostAs() {
@@ -35,11 +37,11 @@ public class TradeList extends LinkedList<TradeList.Trade> {
     }
 
     public TradeList getSubListSell(ItemStack itemStack) {
-        return this.stream().filter(trade -> trade.sellsItem(itemStack)).collect(Collectors.toCollection(() -> new TradeList(entity)));
+        return this.stream().filter(trade -> trade.sellsItem(itemStack)).collect(Collectors.toCollection(() -> new TradeList(entry)));
     }
 
     public TradeList getSubListBuy(ItemStack itemStack) {
-        return this.stream().filter(trade -> trade.buysItem(itemStack)).collect(Collectors.toCollection(() -> new TradeList(entity)));
+        return this.stream().filter(trade -> trade.buysItem(itemStack)).collect(Collectors.toCollection(() -> new TradeList(entry)));
     }
 
     public TradeList getFocusedList(IFocus<ItemStack> focus) {
@@ -55,7 +57,7 @@ public class TradeList extends LinkedList<TradeList.Trade> {
     }
 
     private void addMerchantRecipe(MerchantOffers merchantOffers, VillagerTrades.ItemListing itemListing, RandomSource rand) {
-        MerchantOffer offer = itemListing.getOffer(entity, rand);
+        MerchantOffer offer = itemListing.getOffer(entry.getVillagerEntity(), rand);
         if (offer != null) {
             merchantOffers.add(offer);
         }

--- a/Common/src/main/java/jeresources/entry/AbstractVillagerEntry.java
+++ b/Common/src/main/java/jeresources/entry/AbstractVillagerEntry.java
@@ -27,7 +27,7 @@ public abstract class AbstractVillagerEntry<T extends AbstractVillager> {
     public void addITradeLists(Int2ObjectMap<VillagerTrades.ItemListing[]> itemListings) {
         for (int i = 1;i < itemListings.size() + 1;i++) {
             VillagerTrades.ItemListing[] levelList = itemListings.get(i);
-            TradeList trades = this.tradeList.size() > i ? this.tradeList.get(i) : new TradeList(getVillagerEntity());
+            TradeList trades = this.tradeList.size() > i ? this.tradeList.get(i) : new TradeList(this);
             trades.addITradeList(levelList);
             this.tradeList.add(trades);
         }
@@ -37,7 +37,7 @@ public abstract class AbstractVillagerEntry<T extends AbstractVillager> {
         if (tradeList.size() > level) {
             return tradeList.get(level);
         } else {
-            return new TradeList(getVillagerEntity());
+            return new TradeList(this);
         }
     }
 
@@ -81,6 +81,10 @@ public abstract class AbstractVillagerEntry<T extends AbstractVillager> {
     }
 
     public abstract T getVillagerEntity();
+
+    public void clearEntity(){
+        this.entity = null;
+    }
 
     public abstract List<ItemStack> getPois();
 

--- a/Common/src/main/java/jeresources/entry/MobEntry.java
+++ b/Common/src/main/java/jeresources/entry/MobEntry.java
@@ -96,6 +96,10 @@ public class MobEntry {
         return entity;
     }
 
+    public void clearEntity() {
+        this.entity = null;
+    }
+
     public String getMobName() {
         LivingEntity entity = getEntity();
         return MobHelper.getExpandedName(entity);

--- a/Common/src/main/java/jeresources/registry/MobRegistry.java
+++ b/Common/src/main/java/jeresources/registry/MobRegistry.java
@@ -29,6 +29,10 @@ public class MobRegistry {
         return new ArrayList<>(registry);
     }
 
+    public void clearEntities() {
+        registry.forEach(MobEntry::clearEntity);
+    }
+
     public void clear() {
         registry.clear();
     }

--- a/Common/src/main/java/jeresources/registry/VillagerRegistry.java
+++ b/Common/src/main/java/jeresources/registry/VillagerRegistry.java
@@ -31,6 +31,10 @@ public class VillagerRegistry {
         return this.villagers;
     }
 
+    public void clearEntities(){
+        villagers.forEach(AbstractVillagerEntry::clearEntity);
+    }
+
     public void clear() {
         villagers.clear();
     }

--- a/Common/src/main/java/jeresources/util/MobTableBuilder.java
+++ b/Common/src/main/java/jeresources/util/MobTableBuilder.java
@@ -20,27 +20,17 @@ import static net.minecraft.data.loot.EntityLootSubProvider.SPECIAL_LOOT_TABLE_T
 
 public class MobTableBuilder {
     private final Map<ResourceKey<LootTable>, Supplier<LivingEntity>> mobTables = new HashMap<>();
-    /**
-     * level should be a client level.
-     * Passing in a ServerLevel can allow modded mobs to load all kinds of things,
-     * like in the `VillagerTrades.TreasureMapForEmeralds` which loads chunks!
-     */
-    private final Level level;
-
-    public MobTableBuilder() {
-        this.level = CompatBase.getLevel();
-    }
 
     public void add(ResourceKey<LootTable> resourceLocation, EntityType<?> entityType) {
-        if (isNonLiving(entityType) || !entityType.isEnabled(level.enabledFeatures())) {
+        if (isNonLiving(entityType) || !entityType.isEnabled(CompatBase.getLevel().enabledFeatures())) {
             return;
         }
-        mobTables.put(resourceLocation, () -> (LivingEntity) entityType.create(level));
+        mobTables.put(resourceLocation, () -> (LivingEntity) entityType.create(CompatBase.getLevel()));
     }
 
     public void addSheep(ResourceKey<LootTable> resourceLocation, EntityType<Sheep> entityType, DyeColor dye) {
         mobTables.put(resourceLocation, () -> {
-            Sheep sheep = entityType.create(level);
+            Sheep sheep = entityType.create(CompatBase.getLevel());
             assert sheep != null;
             sheep.setColor(dye);
             return sheep;

--- a/NeoForge/src/main/java/jeresources/neoforge/JEResources.java
+++ b/NeoForge/src/main/java/jeresources/neoforge/JEResources.java
@@ -6,6 +6,8 @@ import jeresources.profiling.ProfileCommand;
 import jeresources.proxy.ClientProxy;
 import jeresources.proxy.CommonProxy;
 import jeresources.reference.Reference;
+import jeresources.registry.MobRegistry;
+import jeresources.registry.VillagerRegistry;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
@@ -13,6 +15,7 @@ import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
 
 
 @Mod(Reference.ID)
@@ -27,6 +30,7 @@ public class JEResources {
         container.getEventBus().register(Config.instance);
 
         NeoForge.EVENT_BUS.addListener(this::onCommandsRegister);
+        NeoForge.EVENT_BUS.addListener(this::onLevelUnload);
       }
 
     private void commonSetup(FMLCommonSetupEvent event) {
@@ -35,5 +39,12 @@ public class JEResources {
 
     private void onCommandsRegister(RegisterCommandsEvent event) {
         ProfileCommand.register(event.getDispatcher());
+    }
+
+    private void onLevelUnload(LevelEvent.Unload event) {
+        if (event.getLevel().isClientSide()){
+            MobRegistry.getInstance().clearEntities();
+            VillagerRegistry.getInstance().clearEntities();
+        }
     }
 }


### PR DESCRIPTION
You still need to do the same for other loaders (find an event that is triggered when Unloads a Level)