### PR TITLE
Fixed `world-gen.json` loading (Error during loading of DIY data)

### DIFF
--- a/Common/src/main/java/jeresources/json/WorldGenAdapter.java
+++ b/Common/src/main/java/jeresources/json/WorldGenAdapter.java
@@ -138,7 +138,7 @@ public class WorldGenAdapter {
     private static Map<ResourceKey<Level>, Restriction> map = new HashMap<>();
 
     private static Restriction getRestriction(String dim) {
-        ResourceKey<Level> worldRegistryKey = ResourceKey.create(Registries.DIMENSION, ResourceLocation.withDefaultNamespace(dim));
+        ResourceKey<Level> worldRegistryKey = ResourceKey.create(Registries.DIMENSION, ResourceLocation.parse(dim));
         return map.computeIfAbsent(worldRegistryKey, k -> new Restriction(new DimensionRestriction(worldRegistryKey)));
     }
 }


### PR DESCRIPTION
**Fixed** `world-gen.json` loading by using `ResourceLocation.parse` instead of `ResourceLocation.withDefaultNamespace`. The `dim` parameter already includes the namespace (e.g., `minecraft:overworld`), whereas `withDefaultNamespace` assumes a path-only input (e.g., `overworld`). This mismatch was causing a `ResourceLocationException: Non [a-z0-9/._-] character in path of location: minecraft:minecraft:overworld`.

I used https://github.com/RundownRhino/RegionScanner to generate the data.

Fixes https://github.com/way2muchnoise/JustEnoughResources/issues/534

Attached the built `jar` files

[JustEnoughResources.zip](https://github.com/user-attachments/files/19622715/JustEnoughResources.zip)

