### PR TITLE
NeoForge: Fix plugin scan to look for @JERPlugin

### DIFF
--- a/NeoForge/src/main/java/jeresources/neoforge/NeoForgePlatformHelper.java
+++ b/NeoForge/src/main/java/jeresources/neoforge/NeoForgePlatformHelper.java
@@ -2,6 +2,7 @@ package jeresources.neoforge;
 
 import jeresources.api.IJERAPI;
 import jeresources.api.IJERPlugin;
+import jeresources.api.JERPlugin;
 import jeresources.platform.ILootTableHelper;
 import jeresources.platform.IModList;
 import jeresources.platform.IPlatformHelper;
@@ -48,7 +49,7 @@ public class NeoForgePlatformHelper implements IPlatformHelper {
 
     @Override
     public void injectApi(IJERAPI instance) {
-        Type pluginAnnotation = Type.getType(IJERPlugin.class);
+        Type pluginAnnotation = Type.getType(JERPlugin.class);
         List<ModFileScanData> allScanData = ModList.get().getAllScanData();
         for (ModFileScanData scanData : allScanData) {
             Iterable<ModFileScanData.AnnotationData> annotations = scanData.getAnnotations();
@@ -60,7 +61,7 @@ public class NeoForgePlatformHelper implements IPlatformHelper {
                         plugin.receive(instance);
                     } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException
                              | InstantiationException | InvocationTargetException e) {
-                        LogHelper.warn("Failed to set: {}" + a.clazz().getClassName() + "." + a.memberName());
+                        LogHelper.warn("Failed to set: " + a.clazz().getClassName() + "." + a.memberName(), e);
                     }
                 }
             }


### PR DESCRIPTION
Problem: NeoForgePlatformHelper compared annotation types to the IJERPlugin interface, so classes annotated with @JERPlugin were not discovered and did not receive IJERAPI injection.

Fix: Compare against jeresources.api.JERPlugin (the annotation) so annotated classes are found. Also include the caught exception in the log to aid debugging.

Fixes #538 