### PR TITLE
Fix plugin registration on Minecraft 26.1+

### DIFF
--- a/Common/src/main/java/jeresources/compatibility/Compatibility.java
+++ b/Common/src/main/java/jeresources/compatibility/Compatibility.java
@@ -10,6 +10,12 @@ import jeresources.util.VillagersHelper;
 
 public class Compatibility {
     public static void init() {
+        try {
+            JERAPI.init();
+        } catch (Exception e) {
+            LogHelper.warn("Error during loading of API plugins", e);
+        }
+
         boolean initWorldGen = true;
 
         try {
@@ -29,8 +35,11 @@ public class Compatibility {
             LogHelper.warn("Error during loading of default minecraft compat", e);
         }
 
-        // Protection is implemented at VillagerEntry creation
-        VillagersHelper.initRegistry(VillagerRegistry.getInstance());
+        try {
+            VillagersHelper.initRegistry(VillagerRegistry.getInstance());
+        } catch (Exception e) {
+            LogHelper.warn("Error during loading of villager trades", e);
+        }
 
         JERAPI.commit(initWorldGen);
     }

--- a/Common/src/main/java/jeresources/compatibility/api/JERAPI.java
+++ b/Common/src/main/java/jeresources/compatibility/api/JERAPI.java
@@ -11,6 +11,7 @@ public class JERAPI implements IJERAPI {
     private IPlantRegistry plantRegistry;
     private IDungeonRegistry dungeonRegistry;
     private static IJERAPI instance;
+    private static boolean pluginsInjected = false;
 
     public static IJERAPI getInstance() {
         if (instance == null)
@@ -25,7 +26,23 @@ public class JERAPI implements IJERAPI {
         dungeonRegistry = new DungeonRegistryImpl();
     }
 
+    /**
+     * Hands the API to every plugin, once per session.
+     *
+     * This is called from {@link jeresources.compatibility.Compatibility#init()}
+     * rather than from mod setup on purpose. Plugins register {@link net.minecraft.world.item.ItemStack}s,
+     * and since Minecraft 26.1 a stack cannot be built before its item's data components
+     * have been bound, which only happens once the server resources have loaded.
+     * Compatibility runs after that point - it is the same moment JER registers its
+     * own vanilla data - so plugins called from here can use the API as documented.
+     *
+     * Plugin registrations are buffered and re-applied by {@link #commit(boolean)}
+     * on every reload, so plugins only ever have to be asked once.
+     */
     public static void init() {
+        if (pluginsInjected)
+            return;
+        pluginsInjected = true;
         Services.PLATFORM.injectApi(JERAPI.getInstance());
     }
 

--- a/CommonApi/src/main/java/jeresources/api/IJERAPI.java
+++ b/CommonApi/src/main/java/jeresources/api/IJERAPI.java
@@ -4,9 +4,14 @@ package jeresources.api;
 import net.minecraft.world.level.Level;
 
 /**
- * Will be delivered during startup to any public static field that is:
- * Forge: annotated with {@link JERPlugin}
- * Fabric: mentioned as entrypoint {@link IJERPlugin#entry_point} in fabric.mod.json
+ * Delivered to every {@link IJERPlugin} once per session, at the same point JER
+ * gathers its own data: after the world's resources have loaded, and before the
+ * registries are handed to JEI.
+ *
+ * That timing is part of the contract. {@link net.minecraft.world.item.ItemStack}s
+ * cannot be built during mod setup on Minecraft 26.1 and later, because an item's
+ * data components are not bound until its resources load, so registering from
+ * {@link IJERPlugin#receive(IJERAPI)} is both safe and the only supported moment.
  */
 public interface IJERAPI {
     IMobRegistry getMobRegistry();

--- a/CommonApi/src/main/java/jeresources/api/IJERPlugin.java
+++ b/CommonApi/src/main/java/jeresources/api/IJERPlugin.java
@@ -1,8 +1,11 @@
 package jeresources.api;
 
 /**
- * Apply to a class to receive an instance of {@link IJERAPI}
+ * Implement to receive an instance of {@link IJERAPI}
  * This instance can be used to register integration with JER
+ *
+ * NeoForge: annotate the implementing class with {@link JERPlugin}
+ * Fabric: list it as the {@link #entry_point} entrypoint in fabric.mod.json
  */
 public interface IJERPlugin {
     String entry_point = "jer_mod_plugin";

--- a/NeoForge/src/main/java/jeresources/neoforge/JEResources.java
+++ b/NeoForge/src/main/java/jeresources/neoforge/JEResources.java
@@ -1,6 +1,5 @@
 package jeresources.neoforge;
 
-import jeresources.compatibility.api.JERAPI;
 import jeresources.neoforge.config.Config;
 import jeresources.proxy.ClientProxy;
 import jeresources.proxy.CommonProxy;
@@ -11,7 +10,6 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
-import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.level.LevelEvent;
 
@@ -23,16 +21,11 @@ public class JEResources {
     public JEResources(ModContainer container, Dist dist) {
         PROXY = dist.isClient() ? new ClientProxy() : new CommonProxy();
 
-        container.getEventBus().addListener(this::commonSetup);
         container.registerConfig(ModConfig.Type.COMMON, Config.COMMON);
         container.getEventBus().register(Config.instance);
 
         NeoForge.EVENT_BUS.addListener(this::onLevelUnload);
       }
-
-    private void commonSetup(FMLCommonSetupEvent event) {
-        JERAPI.init();
-    }
 
     private void onLevelUnload(LevelEvent.Unload event) {
         if (event.getLevel().isClientSide()){


### PR DESCRIPTION
Plugins were handed the API from FMLCommonSetupEvent. Since 26.1 item data components are bound when the world resources load, so an ItemStack cannot be built before then - and registering ItemStacks is what the API is for. Every plugin on 26.1+ threw Components not bound yet and took JER setup down with it.

Move the injection into Compatibility.init, where JER already registers its own vanilla data and stacks are safe to build, and make it idempotent so the existing buffer-and-commit flow is unchanged. This also fixes Fabric, where JERAPI.init was never called at all.

Compatibility.init also no longer dies if the villager step throws. It was unguarded and sat directly before JERAPI.commit, so on 26.2 the missing trade_set registry meant nothing buffered was ever committed.

Also, plugins are no longer injected on a dedicated server. Compatibility runs from the JEI client plugin phase, so server-side registrations were never committed or read anyway.